### PR TITLE
单独把消息（私信、应援团等）做了一个模块

### DIFF
--- a/bilibili_api/data/api/session.json
+++ b/bilibili_api/data/api/session.json
@@ -1,0 +1,42 @@
+{
+    "session": {
+      "fetch": {
+        "url": "https://api.vc.bilibili.com/svr_sync/v1/svr_sync/fetch_session_msgs",
+        "method": "GET",
+        "verify": true,
+        "params": {
+          "talker_id": "int: 私聊用户 UID",
+          "session_type": "int: 未知作用，默认：1",
+          "begin_seqno": "int: 起始 Seqno 可由具体消息获得"
+        },
+        "comment": "获取指定用户的近三十条消息"
+      },
+      "new": {
+        "url": "https://api.vc.bilibili.com/session_svr/v1/session_svr/new_sessions",
+        "method": "GET",
+        "verify": true,
+        "params": {
+          "begin_ts": "int: 起始时间戳"
+        },
+        "comment": "获取新消息"
+      }
+    },
+    "operate": {
+      "send_msg": {
+        "url": "https://api.vc.bilibili.com/web_im/v1/web_im/send_msg",
+        "method": "POST",
+        "verify": true,
+        "data": {
+          "msg[sender_uid]": "int: 自己的 UID",
+          "msg[receiver_id]": "int: 对方 UID",
+          "msg[receiver_type]": "const int: 1",
+          "msg[msg_type]": "const int: 1",
+          "msg[msg_status]": "const int: 0",
+          "msg[content]": {
+            "content": "str: 文本内容"
+          }
+        },
+        "comment": "给用户发信息"
+      }
+    }
+  }

--- a/bilibili_api/data/api/session.json
+++ b/bilibili_api/data/api/session.json
@@ -19,6 +19,20 @@
           "begin_ts": "int: 起始时间戳"
         },
         "comment": "获取新消息"
+      },
+      "get": {
+        "url": "https://api.vc.bilibili.com/session_svr/v1/session_svr/get_sessions",
+        "method": "GET",
+        "verify": true,
+        "params": {
+          "session_type": "int: 1: 私聊, 2: 通知, 3: 应援团, 4: 全部",
+          "group_fold": "int: 默认为 1",
+          "unfollow_fold": "int: 默认为 0",
+          "sort_rule": "int: 默认为 2",
+          "build": "int: 默认为 0",
+          "mobi_app": "web"
+        },
+        "comment": "获取已有消息"
       }
     },
     "operate": {

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -265,32 +265,6 @@
       },
       "comment": "用户关系操作"
     },
-    "send_msg": {
-      "url": "https://api.vc.bilibili.com/web_im/v1/web_im/send_msg",
-      "method": "POST",
-      "verify": true,
-      "data": {
-        "msg[sender_uid]": "int: 自己的 UID",
-        "msg[receiver_id]": "int: 对方 UID",
-        "msg[receiver_type]": "const int: 1",
-        "msg[msg_type]": "const int: 1",
-        "msg[msg_status]": "const int: 0",
-        "msg[content]": {
-          "content": "str: 文本内容"
-        }
-      },
-      "comment": "给用户发信息"
-    },
-    "del_channel_aids_series": {
-      "url": "https://api.bilibili.com/x/series/series/delArchives",
-      "method": "POST",
-      "verity": true,
-      "params": {
-        "mid": "int: uid",
-        "series_id": "int: series_id",
-        "aids": "int: aid 列表"
-      }
-    },
     "del_channel_series": {
       "url": "https://api.bilibili.com/x/series/series/delete",
       "method": "POST",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -265,6 +265,16 @@
       },
       "comment": "用户关系操作"
     },
+    "del_channel_aids_series": {
+      "url": "https://api.bilibili.com/x/series/series/delArchives",
+      "method": "POST",
+      "verity": true,
+      "params": {
+        "mid": "int: uid",
+        "series_id": "int: series_id",
+        "aids": "int: aid 列表"
+      }
+    },
     "del_channel_series": {
       "url": "https://api.bilibili.com/x/series/series/delete",
       "method": "POST",

--- a/bilibili_api/session.py
+++ b/bilibili_api/session.py
@@ -1,0 +1,254 @@
+import asyncio
+import datetime
+import json
+import logging
+import os
+import time
+
+import httpx
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from .user import get_self_info
+from .utils.Credential import Credential
+from .utils.network_httpx import request
+from .utils.utils import get_api
+from .video import Video
+
+API = get_api("session")
+    
+
+async def fetch_session_msgs(talker_id: int, credential: Credential, begin_seqno: int = 0):
+    """
+    获取指定用户的近三十条消息
+
+    Args:
+        talker_id   (int)       : 用户 UID
+        credential  (Credential): Credential
+        begin_seqno (int)       : 起始 Seqno
+
+    Returns:
+        调用 API 返回结果
+    """
+
+    credential.raise_for_no_sessdata()
+    params = {
+        'talker_id': talker_id,
+        'session_type': 1,
+        'begin_seqno': begin_seqno
+    }
+    api = API["session"]["fetch"]
+
+    return await request("GET", api["url"], params=params,credential=credential)
+
+async def new_sessions(credential: Credential, begin_ts: int = int(time.time()*1000000)):
+    """
+    获取新消息
+
+    Args:
+        credential (Credential): Credential
+        begin_ts   (int)       : 起始时间戳
+
+    Returns:
+        调用 API 返回结果
+    """
+
+    credential.raise_for_no_sessdata()
+    params = {'begin_ts': begin_ts}
+    api = API["session"]["new"]
+
+    return await request("GET", api["url"], params=params,credential=credential)
+
+async def send_msg(credential: Credential, receiver_id: int, text: str):
+    """
+    给用户发送私聊信息。目前仅支持纯文本。
+
+    Args:
+        text (str): 信息内容。
+
+    Returns:
+        dict: 调用接口返回的内容。
+    """
+    credential.raise_for_no_sessdata()
+    credential.raise_for_no_bili_jct()
+
+    api = API["operate"]["send_msg"]
+    self_info = await get_self_info(credential)
+    sender_uid = self_info["mid"]
+
+    data = {
+        "msg[sender_uid]": sender_uid,
+        "msg[receiver_id]": receiver_id,
+        "msg[receiver_type]": 1,
+        "msg[msg_type]": 1,
+        "msg[msg_status]": 0,
+        "msg[content]": json.dumps({"content": text}),
+        "msg[dev_id]": "B9A37BF3-AA9D-4076-A4D3-366AC8C4C5DB",
+        "msg[new_face_version]": "0",
+        "msg[timestamp]": int(time.time()),
+        "from_filework": 0,
+        "build": 0,
+        "mobi_app": "web",
+    }
+    return await request(
+        "POST", url=api["url"], data=data, credential=credential
+    )
+
+class Picture:  # 我老想用 TypedDict 了 但是 TypedDict 太高级了 低版本没有
+    height:     int
+    imageType:  str
+    original:   int
+    size:       str
+    url:        str
+    width:      int
+
+    def __init__(self, kwargs: dict):
+        self.__dict__.update(kwargs)
+    
+    def __str__(self):
+        return str(self.__dict__)
+
+    async def download(self, filepath: str = ''):
+        if not filepath:
+            filepath = self.url.replace('https://message.biliimg.com/bfs/im/', '')
+        async with httpx.AsyncClient() as session:
+            r = await session.get(self.url)
+            with open(filepath, 'wb') as fp:
+                fp.write(r.content)
+
+class Event:
+    """
+    事件参数:
+    + receiver_id: 收信人 UID
+    + sender_uid:  发送人 UID
+    + msg_type:    事件类型
+    + msg_key:     事件唯一编号
+    + content:     事件内容
+
+    事件类型:
+    + TEXT:        纯文字消息
+    + PICTURE:     图片消息
+    + WITHDRAW:    撤回消息
+    + SHARE_VIDEO: 分享视频
+    """
+
+    receiver_id: int
+    sender_uid:  int
+    msg_type:    int
+    msg_key:     int
+    content:     int | str | Picture | Video
+
+    TEXT = 1
+    PICTURE = 2
+    WITHDRAW = 5
+    SHARE_VIDEO = 7
+
+    def __init__(self, data: dict, self_uid: int):
+        """
+        信息事件类型:
+            data: 接收到的事件详细信息
+            self_uid: 用户自身 UID
+        """
+        self.__dict__.update(data)
+        self.uid = self_uid
+
+        self.__content()
+    
+    def __str__(self):
+        if self.receiver_id == self.uid:
+            msg_type = '收到'
+            user_id = self.sender_uid
+        else:
+            msg_type = '发送'
+            user_id = self.receiver_id
+        return f'{msg_type} {user_id} 信息: {self.content}'
+
+    def __content(self):
+        '更新消息内容'
+
+        content: dict = json.loads(self.content)
+
+        if self.msg_type == Event.TEXT:
+            self.content = content.get('content')
+
+        elif self.msg_type == Event.PICTURE:
+            self.content = Picture(content)
+        
+        elif self.msg_type == Event.SHARE_VIDEO:
+            self.content = Video(bvid=content.get('bvid'), aid=content.get('id'))
+
+class Session:
+    def __init__(self, credential: Credential, debug=False):
+        self.maxSeqno = 0
+        self.maxTs = int(time.time()*1000000)
+        self.credential = credential
+        self.__status = 0
+        self.sched = AsyncIOScheduler(timezone="Asia/Shanghai")
+        self.events = dict()
+
+        # logging
+        self.logger = logging.getLogger("Session")
+        self.logger.setLevel(logging.DEBUG if debug else logging.INFO)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter("[%(asctime)s][%(levelname)s]: %(message)s", '%Y-%m-%d %H:%M:%S'))
+            self.logger.addHandler(handler)        
+
+    def get_status(self):
+        """
+        获取连接状态
+        Returns:
+            int: 0 初始化，1 已连接，2 断开连接中，3 已断开，4 错误
+        """
+        return self.__status
+
+    async def run(self):
+        self_info = await get_self_info(self.credential)
+        self.uid = self_info["mid"]
+
+        # 间隔 3 秒轮询消息列表
+        @self.sched.scheduled_job('interval', seconds=3, max_instances=3, next_run_time=datetime.datetime.now())
+        async def qurey():
+            js = await new_sessions(self.credential, self.maxTs)
+            if js.get('session_list') is None:
+                return
+
+            pending = set()
+            for session in js['session_list']:
+                self.maxTs = max(self.maxTs, session['session_ts'])
+                self.logger.info(f"获取到 UID: {session['talker_id']} 最新消息 {session['last_msg']}")
+                pending.add(
+                    asyncio.create_task(
+                        fetch_session_msgs(session['talker_id'], self.credential, self.maxSeqno)
+                    )
+                )
+
+            while pending:
+                done, pending = await asyncio.wait(pending)
+                for done_task in done:
+                    js = await done_task
+                    if js['messages']:
+                        self.maxSeqno = max(self.maxSeqno, js['messages'][0]['msg_seqno'])
+                    for message in js.get('messages', [])[::-1]:
+                        event = Event(message, self.uid)
+                        if event.msg_type == Event.WITHDRAW:
+                            print(self.events.get(str(event.content)), '被撤回')
+                        elif event.msg_type == Event.PICTURE:
+                            await event.content.download()
+                        else:
+                            print(event)
+                        self.events.update({str(event.msg_key): event})
+
+            self.logger.debug(f'maxTs = {self.maxTs}')
+
+        self.sched.start()
+
+    async def start(self):
+        await self.run()
+        while self.get_status() < 2:
+            await asyncio.sleep(1)
+        
+        if self.get_status() == 2:
+            self.__status = 3
+
+    async def close(self):
+        self.__status = 2

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -470,41 +470,6 @@ class User:
             "POST", url=api["url"], data=data, credential=self.credential
         )
 
-    async def send_msg(self, text: str):
-        """
-        给用户发送私聊信息。目前仅支持纯文本。
-
-        Args:
-            text (str): 信息内容。
-
-        Returns:
-            dict: 调用接口返回的内容。
-        """
-        self.credential.raise_for_no_sessdata()
-        self.credential.raise_for_no_bili_jct()
-
-        api = API["operate"]["send_msg"]
-        self_info = await self.__get_self_info()
-        sender_uid = self_info["mid"]
-
-        data = {
-            "msg[sender_uid]": sender_uid,
-            "msg[receiver_id]": self.uid,
-            "msg[receiver_type]": 1,
-            "msg[msg_type]": 1,
-            "msg[msg_status]": 0,
-            "msg[content]": json.dumps({"content": text}),
-            "msg[dev_id]": "B9A37BF3-AA9D-4076-A4D3-366AC8C4C5DB",
-            "msg[new_face_version]": "0",
-            "msg[timestamp]": int(time.time()),
-            "from_filework": 0,
-            "build": 0,
-            "mobi_app": "web",
-        }
-        return await request(
-            "POST", url=api["url"], data=data, credential=self.credential
-        )
-
     async def get_channel_videos_series(self, sid: int, pn: int = 1, ps: int = 100):
         """
         查看频道内所有视频。仅供 series_list。

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -1,0 +1,21 @@
+# 示例：保存私信收到的图片，并对文字私信做出回复
+
+```python
+from bilibili_api import Credential, sync
+from bilibili_api.session import Session, Event
+
+session = Session(Credential(...))
+
+@session.on(Event.PICTURE)
+async def pic(event: Event):
+    await event.content.download()
+
+@session.on(Event.TEXT)
+async def reply(event: Event):
+    if event.content == '/close':
+        session.close()
+    else:
+        await session.reply(event, '你好李鑫')
+
+sync(session.start())
+```

--- a/docs/modules/session.md
+++ b/docs/modules/session.md
@@ -1,0 +1,181 @@
+# Module session.py
+
+```python
+from bilibili_api import session
+```
+
+消息相关。
+
+#### async def fetch_session_msgs()
+
+| name        | type          | description                      |
+| ----------- | ------------- | -------------------------------- |
+| talker_id   | int           | 用户 UID                         |
+| credential  | Credential    | 凭证                             |
+| begin_seqno | int, optional | 起始 Seqno，每条信息有自己的Seqno |
+
+获取指定用户的近三十条消息
+
+**Returns:** API 调用返回结果
+
+#### async def new_sessions()
+
+| name       | type          | description |
+| ---------- | ------------- | ----------- |
+| credential | Credential    | 凭证        |
+| begin_ts   | int, optional | 起始时间戳  |
+
+获取新消息
+
+**Returns:** API 调用返回结果
+
+#### async def get_sessions()
+
+| name         | type          | description                                 |
+| ------------ | ------------- | ------------------------------------------- |
+| credential   | Credential    | 凭证                                        |
+| session_type | int, optional | 会话类型 1: 私聊, 2: 通知, 3: 应援团, 4: 全部 |
+
+获取已有消息
+
+**Returns:** API 调用返回结果
+
+#### async def send_msg()
+
+| name | type | description |
+| ---- | ---- | ----------- |
+| text | str  | 信息内容。  |
+
+给用户发送私聊信息。目前仅支持纯文本。
+
+**Returns:** 调用接口返回的内容。
+
+---
+
+## class Picture
+
+图片类，包含图片链接、尺寸以及下载操作。
+
+### Functions
+
+#### def \_\_init\_\_()
+
+| name   | type | description |
+| ------ | ---- | ----------- |
+| kwargs | dict | 图片content |
+
+#### def \_\_str\_\_()
+
+图片信息
+
+**Returns:** 含图片信息的字符串
+
+#### async def download()
+
+| name     | type          | description |
+| -------- | ------------- | ----------- |
+| filepath | str, optional | 图片保存路径 |
+
+下载图片
+
+---
+
+## class Event
+
+消息类，定义有各种消息类型，并可将 json 传换成字符串
+
+**消息参数:**
+
++ receiver_id:   收信人 UID
++ receiver_type: 收信人类型，1: 私聊, 2: 应援团通知, 3: 应援团
++ sender_uid:    发送人 UID
++ talker_id:     对话人 UID
++ msg_seqno:     事件 Seqno
++ msg_type:      事件类型
++ msg_key:       事件唯一编号
++ timestamp:     事件时间戳
++ content:       事件内容
+
+**消息类型:**
+
++ TEXT:           纯文字消息
++ PICTURE:        图片消息
++ WITHDRAW:       撤回消息
++ GROUPS_PICTURE: 应援团图片
++ SHARE_VIDEO:    分享视频
++ NOTICE:         系统通知
++ PUSHED_VIDEO:   UP主推送的视频
++ WELCOME:        新成员加入应援团欢迎
+
+### Functions
+
+#### def \_\_init\_\_()
+
+| name     | type | description         |
+| -------- | ---- | ------------------- |
+| data     | dict | 接收到的事件详细信息 |
+| self_uid | int  | 用户自身 UID        |
+
+#### def \_\_str\_\_()
+
+信息概述
+
+**Returns:** 信息的字符串形式
+
+#### def \_\_content()
+
+格式化信息，将信息内容转换为数字、文本、Video对象或Picture对象。
+
+---
+
+## class Session
+
+**Extends:** bilibili_api.utils.AsyncEvent.AsyncEvent
+
+会话类，用来开启消息监听。
+
+### Functions
+
+#### def \_\_init\_\_()
+
+| name       | type           | description |
+| ---------- | -------------- | ----------- |
+| credential | Credential     | 凭证        |
+| debug      | bool, optional | 日志等级    |
+
+#### def get_status()
+
+获取连接状态
+
+**Returns:** int: 0 初始化，1 已连接，2 断开连接中，3 已断开，4 错误
+
+#### async def run()
+
+| name        | type           | description                  |
+| ----------- | -------------- | ---------------------------- |
+| except_self | bool, optional | 是否排除自己发出的消息，默认是 |
+
+不阻塞开始轮询
+
+#### async def start()
+
+| name        | type           | description                  |
+| ----------- | -------------- | ---------------------------- |
+| except_self | bool, optional | 是否排除自己发出的消息，默认是 |
+
+阻塞开始轮询
+
+#### async def reply()
+
+| name  | type  | description |
+| ----- | ----- | ----------- |
+| event | Event | 要回复的消息 |
+| text  | str   | 回复文字     |
+
+快速回复
+
+**Returns:** dict: 调用接口返回的内容。
+
+#### def close()
+
+结束轮询

--- a/docs/modules/session.md
+++ b/docs/modules/session.md
@@ -42,9 +42,11 @@ from bilibili_api import session
 
 #### async def send_msg()
 
-| name | type | description |
-| ---- | ---- | ----------- |
-| text | str  | 信息内容。  |
+| name        | type       | description |
+| ----------- | ---------- | ----------- |
+| credential  | Credential | 凭证        |
+| receiver_id | int        | 接收者 UID  |
+| text        | str        | 信息内容。  |
 
 给用户发送私聊信息。目前仅支持纯文本。
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -311,16 +311,6 @@ from bilibili_api import user
 
 **Returns:** 调用接口返回的内容。
 
-#### async def send_msg()
-
-| name | type | description |
-| ---- | ---- | ----------- |
-| text | str  | 信息内容。  |
-
-给用户发送私聊信息。目前仅支持纯文本。
-
-**Returns:** 调用接口返回的内容。
-
 ---
 
 ## async def get_self_info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ pycryptodome~=3.15.0
 pillow~=9.2.0
 requests~=2.28.1
 keyboard~=0.13.5
+APScheduler~=3.9.1
 # ffmpeg-python~=0.2.0 


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

把消息会话相关写在了 **session.py** 模块里
- 新增了相关接口 **session.json** 。
- 将 **user.send_msg** 相关函数、接口与文档转移至 **session** 对应位置。
- 通过轮询实现了 **Session** 类，可以接收消息并使用类似 **live.LiveDanmaku.on()** 方式派发任务。
- 经测试私聊可以正常使用，但后续可能还有应援团相关bug。
- 代码、文档规范这块我可能做的不是很好，还请斧正。
