### PR TITLE
Bangumi 模块对特殊番剧的基本信息获取适配，兼容原来的方法

### DIFF
--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -61,6 +61,7 @@ class Bangumi:
             oversea.raise_for_status()
             self.__ssid = oversea.json()["result"]["season_id"]
             self.__media_id = oversea.json()["result"]["media_id"]
+            self.ep_list = oversea.json()["result"]["episodes"]
             self.ep_item = [item for item in oversea.json()["result"]["episodes"] if item["ep_id"] == self.__epid][0]
         else:
             if ssid != -1:
@@ -90,10 +91,24 @@ class Bangumi:
         return self.__ssid
 
     def get_ep_info(self):
+        """
+        如果设置了 epid,回应对应条目的条目数据
+        Returns:数据
+        """
         if self.__epid != -1:
             return self.ep_item
         else:
-            print("没有设置 epid 参数")
+            raise ValueError("没有设置任何 epid 参数")
+
+    def get_ep_list(self):
+        """
+        如果设置了 epid,回应所有的条目数据
+        Returns:数据
+        """
+        if self.__epid != -1:
+            return self.ep_list
+        else:
+            raise ValueError("没有设置任何 epid 参数")
 
     def set_media_id(self, media_id: int):
         self.__init__(media_id=media_id, credential=self.credential)

--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -101,7 +101,7 @@ class Bangumi:
 
     def get_up_info(self):
         """
-        原始初始化数据
+        番剧上传者信息 出差或者原版
         Returns:self.__raw, self.oversea
         """
         return self.__up_info

--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -113,7 +113,7 @@ class Bangumi:
         """
         return self.__raw, self.oversea
 
-    def get_ep_info(self):
+    def get_episode_info(self):
         """
         如果设置了 epid,回应对应条目的条目数据
         Returns:数据

--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -47,7 +47,15 @@ class Bangumi:
         self, media_id: int = -1, ssid: int = -1, epid: int = -1, oversea: bool = False,
         credential: Credential = Credential()
     ):
-        """番剧类"""
+        """
+        番剧类相关
+        Args:
+            media_id: 番剧本身的 ID
+            ssid: 每季度的 ID
+            epid: 每集的 ID
+            oversea: bool，是否要采用兼容的港澳台Api,用于仅限港澳台地区番剧的信息请求
+            credential: 凭据类
+        """
         if media_id == -1 and ssid == -1 and epid == -1:
             raise ValueError("需要 Media_id 或 Season_id 或 epid 中的一个 !")
         self.credential = credential
@@ -82,11 +90,14 @@ class Bangumi:
         self.__epid = epid
         if not self.__raw.get("result"):
             raise ApiException("Api没有返回预期的结果")
+        # 确认有结果后，取出数据
         self.__ssid = req.json()["result"]["season_id"]
         self.__media_id = req.json()["result"]["media_id"]
         self.__up_info = req.json()["result"]["up_info"]
+        # 获取剧集相关
         self.ep_list = req.json()["result"].get("episodes")
-        self.ep_item = ["{}"]
+        self.ep_item = [{}]
+        # 出海 Api 和国内的字段有些不同
         if self.ep_list:
             if self.oversea:
                 self.ep_item = [item for item in self.ep_list if item["ep_id"] == self.__epid]
@@ -183,7 +194,7 @@ class Bangumi:
 
     async def get_episode_list(self):
         """
-        获取季度分集列表
+        获取季度分集列表，自动转换出海Api的字段，适配部分，但是键还是有不同
         """
         if self.oversea:
             # 转换 ep_id->id ，index_title->longtitle ，index->title

--- a/bilibili_api/data/api/bangumi.json
+++ b/bilibili_api/data/api/bangumi.json
@@ -72,6 +72,15 @@
       },
       "comment": "获取一个剧集的全面概括信息"
     },
+    "collective_info_oversea": {
+      "url": "https://bangumi.bilibili.com/view/web_api/season",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "season_id": "int: B 站每个剧集会对应一个唯一 ID,适用于港澳台番剧和内陆番剧"
+      },
+      "comment": "获取一个剧集的全面概括信息"
+    },
     "playurl": {
       "url": "https://api.bilibili.com/pgc/player/web/playurl",
       "method": "GET",

--- a/docs/modules/bangumi.md
+++ b/docs/modules/bangumi.md
@@ -27,16 +27,16 @@ from bilibili_api import bangumi
 
 ### Atrributes
 
-| name            | type       | description                    |
-|-----------------|------------|--------------------------------|
-| credential      | Credential | 凭据类                            |
-| self.__raw      | dict       | 初始化时从Api拉取的原始数据                |
-| self.__epid     | int        | 剧集ID,如果不传入就为 `-1`              |
-| self.__ssid     | int        | 成功即存在的季度ID                     |
-| self.__media_id | int        | 成功即存在的番剧ID                     |
-| self.__up_info  | dict       | 上传者信息/所属                       |
-| self.ep_list    | list       | 获取到的分集列表                       |
-| self.ep_item    | list       | 如果存在有效`epid`则获取对应数据，不存在为`[{}]` |
+| name       | type       | description                    |
+|------------|------------|--------------------------------|
+| credential | Credential | 凭据类                            |
+| __raw      | dict       | 初始化时从Api拉取的原始数据                |
+| __epid     | int        | 剧集ID,如果不传入就为 `-1`              |
+| __ssid     | int        | 成功即存在的季度ID                     |
+| __media_id | int        | 成功即存在的番剧ID                     |
+| __up_info  | dict       | 上传者信息/所属                       |
+| ep_list    | list       | 获取到的分集列表                       |
+| ep_item    | list       | 如果存在有效`epid`则获取对应数据，不存在为`[{}]` |
 
 ### Functions
 

--- a/docs/modules/bangumi.md
+++ b/docs/modules/bangumi.md
@@ -62,6 +62,8 @@ media_id ，ssid ,epid 三者必须有其一，如果含有所有参数，字段
 
 获取 season_id
 
+**Returns:** season_id
+
 #### def get_up_info()
 
 获取番剧的上传者信息，一般为哔哩哔哩出差和哔哩哔哩两种

--- a/docs/modules/bangumi.md
+++ b/docs/modules/bangumi.md
@@ -63,7 +63,7 @@ media_id ，ssid ,epid 三者必须有其一，如果含有所有参数，字段
 
 #### def get_episode_info()
 
-获取ep剧集相对应的各种数据，比如 标题，avid,bvid 等等
+获取传入的 epid 剧集相对应的各种数据，比如 标题，avid,bvid 等等,如果没有传入 epid 参数将会抛出错误
 
 **Returns:** Api 相关字段
 

--- a/docs/modules/bangumi.md
+++ b/docs/modules/bangumi.md
@@ -3,9 +3,11 @@
 ```python
 from bilibili_api import bangumi
 ```
+
 番剧相关
 
 概念：
+
 + media_id: 番剧本身的 ID，有时候也是每季度的 ID，如 https://www.bilibili.com/bangumi/media/md28231846/
 + season_id: 每季度的 ID，只能通过 get_meta() 获取。
 + episode_id: 每集的 ID，如 https://www.bilibili.com/bangumi/play/ep374717
@@ -33,11 +35,15 @@ from bilibili_api import bangumi
 
 #### def \_\_init\_\_()
 
-| name | type | description |
-| ---- | ---- | ----------- |
-| media_id | int | 教程 ID（不与番剧相通） |
-| ssid | int | 教程季度 ID（不与番剧相通） |
-| credential | Credential | 凭据 |
+| name       | type       | description        |
+|------------|------------|--------------------|
+| media_id   | int        | 教程 ID（不与番剧相通）      |
+| ssid       | int        | 教程季度 ID（不与番剧相通）    |
+| epid       | int        | 剧集 ID              |
+| oversea    | bool       | 是否采用港澳台 Api(与大陆通用) |
+| credential | Credential | 凭据                 |
+
+media_id ，ssid ,epid 三者必须有其一，如果含有所有参数，字段会被提交到Api查询
 
 #### def get_media_id()
 
@@ -49,7 +55,23 @@ from bilibili_api import bangumi
 
 获取 season_id
 
-**Returns:** season_id
+#### def get_up_info()
+
+获取番剧的上传者信息，一般为哔哩哔哩出差和哔哩哔哩两种
+
+**Returns:** Api 相关字段
+
+#### def get_episode_info()
+
+获取ep剧集相对应的各种数据，比如 标题，avid,bvid 等等
+
+**Returns:** Api 相关字段
+
+#### def get_raw()
+
+获取初始化得到的，和 get_overview 一个格式的数据
+
+**Returns:** Api 字段
 
 #### async def set_ssid()
 
@@ -71,10 +93,10 @@ from bilibili_api import bangumi
 
 #### async def get_short_comment_list()
 
-| name       | type                          | description                                                  |
-| ---------- | ----------------------------- | ------------------------------------------------------------ |
-| order      | BangumiCommentOrder, optional | 排序方式。Defaults to BangumiCommentOrder.DEFAULT            |
-| next       | str, optional                 | 调用返回结果中的 next 键值，用于获取下一页数据。Defaults to None |
+| name  | type                          | description                                  |
+|-------|-------------------------------|----------------------------------------------|
+| order | BangumiCommentOrder, optional | 排序方式。Defaults to BangumiCommentOrder.DEFAULT |
+| next  | str, optional                 | 调用返回结果中的 next 键值，用于获取下一页数据。Defaults to None  |
 
 获取短评列表
 
@@ -82,10 +104,10 @@ from bilibili_api import bangumi
 
 #### async def get_long_comment_list()
 
-| name       | type                          | description                                                  |
-| ---------- | ----------------------------- | ------------------------------------------------------------ |
-| order      | BangumiCommentOrder, optional | 排序方式。Defaults to BangumiCommentOrder.DEFAULT            |
-| next       | str, optional                 | 调用返回结果中的 next 键值，用于获取下一页数据。Defaults to None |
+| name  | type                          | description                                  |
+|-------|-------------------------------|----------------------------------------------|
+| order | BangumiCommentOrder, optional | 排序方式。Defaults to BangumiCommentOrder.DEFAULT |
+| next  | str, optional                 | 调用返回结果中的 next 键值，用于获取下一页数据。Defaults to None  |
 
 获取长评列表
 
@@ -113,11 +135,11 @@ from bilibili_api import bangumi
 
 ## async def set_follow()
 
-| name       | type                 | description                |
-| ---------- | -------------------- | -------------------------- |
-| bangumi | Bangumi | 番剧类 |
+| name       | type                 | description           |
+|------------|----------------------|-----------------------|
+| bangumi    | Bangumi              | 番剧类                   |
 | status     | bool, optional       | 追番状态，Defaults to True |
-| credential | Credential, optional | 凭据. Defaults to None     |
+| credential | Credential, optional | 凭据. Defaults to None  |
 
 追番状态设置
 
@@ -143,10 +165,10 @@ from bilibili_api import bangumi
 
 #### def \_\_init\_\_()
 
-| name | type | description |
-| ---- | ---- | ----------- |
-| epid | int | epid | 
-| credential | Credential | 凭据 |
+| name       | type       | description |
+|------------|------------|-------------|
+| epid       | int        | epid        | 
+| credential | Credential | 凭据          |
 
 #### def get_bangumi()
 
@@ -178,20 +200,17 @@ from bilibili_api import bangumi
 
 **Returns:** API 调用返回结果。
 
-
 #### async def get_danmaku_view()
 
 获取弹幕设置、特殊弹幕、弹幕数量、弹幕分段等信息。
 
-
 **Returns:** API 调用返回结果。
-
 
 #### async def get_danmakus()
 
-| name       | type                    | description                                               |
-| ---------- | ----------------------- | --------------------------------------------------------- |
-| date       | datetime.Date, optional | 指定日期后为获取历史弹幕，精确到年月日。Defaults to None. |
+| name | type                    | description                           |
+|------|-------------------------|---------------------------------------|
+| date | datetime.Date, optional | 指定日期后为获取历史弹幕，精确到年月日。Defaults to None. |
 
 获取弹幕
 
@@ -205,9 +224,9 @@ from bilibili_api import bangumi
 
 #### async def get_history_danmaku_index()
 
-| name       | type                    | description                                               |
-| ---------- | ----------------------- | --------------------------------------------------------- |
-| date       | datetime.Date, optional | 指定日期后为获取历史弹幕，精确到年月日。Defaults to None. |
+| name | type                    | description                           |
+|------|-------------------------|---------------------------------------|
+| date | datetime.Date, optional | 指定日期后为获取历史弹幕，精确到年月日。Defaults to None. |
 
 获取特定月份存在历史弹幕的日期。
 

--- a/docs/modules/bangumi.md
+++ b/docs/modules/bangumi.md
@@ -27,9 +27,16 @@ from bilibili_api import bangumi
 
 ### Atrributes
 
-| name | type | description |
-| - | - | - |
-| credential | Credential | 凭据类 |
+| name            | type       | description                    |
+|-----------------|------------|--------------------------------|
+| credential      | Credential | 凭据类                            |
+| self.__raw      | dict       | 初始化时从Api拉取的原始数据                |
+| self.__epid     | int        | 剧集ID,如果不传入就为 `-1`              |
+| self.__ssid     | int        | 成功即存在的季度ID                     |
+| self.__media_id | int        | 成功即存在的番剧ID                     |
+| self.__up_info  | dict       | 上传者信息/所属                       |
+| self.ep_list    | list       | 获取到的分集列表                       |
+| self.ep_item    | list       | 如果存在有效`epid`则获取对应数据，不存在为`[{}]` |
 
 ### Functions
 

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -43,8 +43,12 @@ async def test_gangaotai_get_list():
     return e.get_ep_list()
 async def test_gangaotai_get_item():
     return e.get_ep_info()
+async def test_gangaotai_get_bangumi():
+    return await e.get_meta()
 info1 = sync(test_gangaotai_get_list())
 info2 = sync(test_gangaotai_get_item())
+info3 = sync(test_gangaotai_get_bangumi())
 print(info1)
 print(info2)
+print(info3)
 # 港澳台 ep 测试 END

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -7,19 +7,6 @@ from bilibili_api import bangumi
 b = bangumi.Bangumi(28231846)
 ep = bangumi.Episode(374717)
 
-# 港澳台 ep 测试 START
-r = bangumi.Bangumi(epid=675686)  # 港澳台番剧
-e = bangumi.Bangumi(epid=674709)  # 内地番剧
-from bilibili_api import sync
-async def test_gangaotai_get_list():
-    return e.get_ep_list()
-async def test_gangaotai_get_item():
-    return e.get_ep_info()
-info1 = sync(test_gangaotai_get_list())
-info2 = sync(test_gangaotai_get_item())
-print(info1)
-print(info2)
-# 港澳台 ep 测试 END
 
 async def test_a_Bangumi_get_meta():
     return await b.get_meta()
@@ -47,3 +34,17 @@ async def test_f_Episode_get_episode_info():
 
 async def test_g_Bangumi_get_overview():
     return await b.get_overview()
+
+# 港澳台 ep 测试 START
+r = bangumi.Bangumi(epid=675686)  # 港澳台番剧
+e = bangumi.Bangumi(epid=674709)  # 内地番剧
+from bilibili_api import sync
+async def test_gangaotai_get_list():
+    return e.get_ep_list()
+async def test_gangaotai_get_item():
+    return e.get_ep_info()
+info1 = sync(test_gangaotai_get_list())
+info2 = sync(test_gangaotai_get_item())
+print(info1)
+print(info2)
+# 港澳台 ep 测试 END

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -1,10 +1,24 @@
 # bilibili_api.bangumi
 
 from bilibili_api import bangumi
-from .common import get_credential
+
+# from .common import get_credential
 
 b = bangumi.Bangumi(28231846)
 ep = bangumi.Episode(374717)
+
+# 港澳台 ep 测试
+r = bangumi.Bangumi(epid=675686)  # 港澳台
+e = bangumi.Bangumi(epid=674709)  # 内地
+from bilibili_api import sync
+
+
+async def test_gangaotai_get_meta():
+    return e.get_ep_list()
+
+
+info = sync(test_gangaotai_get_meta())
+print(info)
 
 
 async def test_a_Bangumi_get_meta():

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -7,19 +7,19 @@ from bilibili_api import bangumi
 b = bangumi.Bangumi(28231846)
 ep = bangumi.Episode(374717)
 
-# 港澳台 ep 测试
-r = bangumi.Bangumi(epid=675686)  # 港澳台
-e = bangumi.Bangumi(epid=674709)  # 内地
+# 港澳台 ep 测试 START
+r = bangumi.Bangumi(epid=675686)  # 港澳台番剧
+e = bangumi.Bangumi(epid=674709)  # 内地番剧
 from bilibili_api import sync
-
-
-async def test_gangaotai_get_meta():
+async def test_gangaotai_get_list():
     return e.get_ep_list()
-
-
-info = sync(test_gangaotai_get_meta())
-print(info)
-
+async def test_gangaotai_get_item():
+    return e.get_ep_info()
+info1 = sync(test_gangaotai_get_list())
+info2 = sync(test_gangaotai_get_item())
+print(info1)
+print(info2)
+# 港澳台 ep 测试 END
 
 async def test_a_Bangumi_get_meta():
     return await b.get_meta()

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -37,13 +37,18 @@ async def test_g_Bangumi_get_overview():
 
 
 from bilibili_api import sync
+
 # print(sync(test_f_Episode_get_episode_info()))
 # 港澳台 ep 测试 START
-e = bangumi.Bangumi(media_id=28338523, oversea=True)  # 港澳台番剧
+e = bangumi.Bangumi(epid=562695, oversea=True)  # 港澳台番剧
+
+
+# e = bangumi.Bangumi(media_id=28338523, oversea=True)  # 港澳台番剧
 # e = bangumi.Bangumi(epid=674709)  # 内地番剧
 
 async def test_oversea_gangaotai_get_item():
     return e.get_episode_info()
+
 
 async def test_oversea_gangaotai_get_bangumi():
     return await e.get_meta()

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -36,8 +36,8 @@ async def test_g_Bangumi_get_overview():
     return await b.get_overview()
 
 # 港澳台 ep 测试 START
-r = bangumi.Bangumi(epid=675686)  # 港澳台番剧
-e = bangumi.Bangumi(epid=674709)  # 内地番剧
+e = bangumi.Bangumi(epid=675686, oversea=True)  # 港澳台番剧
+# e = bangumi.Bangumi(epid=674709)  # 内地番剧
 from bilibili_api import sync
 async def test_gangaotai_get_list():
     return e.get_ep_list()
@@ -45,12 +45,12 @@ async def test_gangaotai_get_item():
     return e.get_ep_info()
 async def test_gangaotai_get_bangumi():
     return await e.get_meta()
-# info1 = sync(test_gangaotai_get_list())
-# info2 = sync(test_gangaotai_get_item())
-# info3 = sync(test_gangaotai_get_bangumi())
+info1 = sync(test_gangaotai_get_list())
+info2 = sync(test_gangaotai_get_item())
+info3 = sync(test_gangaotai_get_bangumi())
 # 特性测试
-# print(info1)
-# print(info2)
+print(info1)
+print(info2)
 # 兼容测试
-# print(info3)
+print(info3)
 # 港澳台 ep 测试 END

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -36,15 +36,14 @@ async def test_g_Bangumi_get_overview():
     return await b.get_overview()
 
 
+from bilibili_api import sync
+# print(sync(test_f_Episode_get_episode_info()))
 # 港澳台 ep 测试 START
 e = bangumi.Bangumi(epid=562695, oversea=True)  # 港澳台番剧
 # e = bangumi.Bangumi(epid=674709)  # 内地番剧
-from bilibili_api import sync
-
 
 async def test_oversea_gangaotai_get_item():
-    return e.get_ep_info()
-
+    return e.get_episode_info()
 
 async def test_oversea_gangaotai_get_bangumi():
     return await e.get_meta()

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -39,7 +39,7 @@ async def test_g_Bangumi_get_overview():
 from bilibili_api import sync
 # print(sync(test_f_Episode_get_episode_info()))
 # 港澳台 ep 测试 START
-e = bangumi.Bangumi(epid=562695, oversea=True)  # 港澳台番剧
+e = bangumi.Bangumi(media_id=28338523, oversea=True)  # 港澳台番剧
 # e = bangumi.Bangumi(epid=674709)  # 内地番剧
 
 async def test_oversea_gangaotai_get_item():

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -45,10 +45,12 @@ async def test_gangaotai_get_item():
     return e.get_ep_info()
 async def test_gangaotai_get_bangumi():
     return await e.get_meta()
-info1 = sync(test_gangaotai_get_list())
-info2 = sync(test_gangaotai_get_item())
-info3 = sync(test_gangaotai_get_bangumi())
-print(info1)
-print(info2)
-print(info3)
+# info1 = sync(test_gangaotai_get_list())
+# info2 = sync(test_gangaotai_get_item())
+# info3 = sync(test_gangaotai_get_bangumi())
+# 特性测试
+# print(info1)
+# print(info2)
+# 兼容测试
+# print(info3)
 # 港澳台 ep 测试 END

--- a/tests/test_bangumi.py
+++ b/tests/test_bangumi.py
@@ -35,22 +35,38 @@ async def test_f_Episode_get_episode_info():
 async def test_g_Bangumi_get_overview():
     return await b.get_overview()
 
+
 # 港澳台 ep 测试 START
-e = bangumi.Bangumi(epid=675686, oversea=True)  # 港澳台番剧
+e = bangumi.Bangumi(epid=562695, oversea=True)  # 港澳台番剧
 # e = bangumi.Bangumi(epid=674709)  # 内地番剧
 from bilibili_api import sync
-async def test_gangaotai_get_list():
-    return e.get_ep_list()
-async def test_gangaotai_get_item():
+
+
+async def test_oversea_gangaotai_get_item():
     return e.get_ep_info()
-async def test_gangaotai_get_bangumi():
+
+
+async def test_oversea_gangaotai_get_bangumi():
     return await e.get_meta()
-info1 = sync(test_gangaotai_get_list())
-info2 = sync(test_gangaotai_get_item())
-info3 = sync(test_gangaotai_get_bangumi())
+
+
+async def test_oversea_Bangumi_get_episode_list():
+    return await e.get_episode_list()
+
+
+async def test_oversea_Bangumi_get_stat():
+    return await e.get_stat()
+
 # 特性测试
-print(info1)
-print(info2)
+# info2 = sync(test_oversea_gangaotai_get_item())
+# print(info2)
 # 兼容测试
-print(info3)
+# info3 = sync(test_oversea_gangaotai_get_bangumi())
+# print(info3)
+# 转换测试
+# info4 = sync(test_oversea_Bangumi_get_episode_list())
+# print(info4)
+# 没有被限制的stat接口
+# info5 = sync(test_oversea_Bangumi_get_stat())
+# print(info5)
 # 港澳台 ep 测试 END


### PR DESCRIPTION
Bangumi 模块对特殊番剧的基本信息获取适配，兼容原来的方法
## 修改变动表
```
bilibili_api/bangumi.py
bilibili_api/data/api/bangumi.json
tests/test_bangumi.py
docs/modules/bangumi.md
```
## 新特性
可以获取港澳台番剧相关信息

## 更改
-  重构了 `Bangumi` 的 `init` 类方法，采用构造参数的方式，去除重复if else.
-  适配了 `get_episode_list`，尽力将不同转换为同一字段
-   兼容了其他 `Bangumi`类的方法（更改了以 season_id为请求参数的方法）
## 增加
-  增加了`oversea` 参数
-  增加了对于港澳番剧基础信息的 Api 索引
- 增加了 `get_up_info` 方法，获取番剧是出差还是大陆
- 增加了 `get_raw` 方法，获取初始化得到的，和 `get_overview` 一个格式的数据
-  增加了 `Bangumi `参数 `epid` 可以根据剧集id获取对应番剧信息和剧集列表
-  增加了 `get_episode_info` 方法(内含抛出错误的else)，和 `Episode` 类里那个功能一样
-  增加了测试例在 `tests/test_bangumi.py` 中

#57 