### PR TITLE
[Enhancement] 增加相簿的获取方法，主页公告的获取,设置方法(User模块) 

### DIFF
--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -74,6 +74,18 @@
       },
       "comment": "搜索用户视频"
     },
+    "album": {
+      "url": "https://api.vc.bilibili.com/link_draw/v1/doc/doc_list",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "uid": "int: uid 此项必须",
+        "page_size": "int: 每页项数 此项必须",
+        "page_num": "int: 页码",
+        "biz": "str: 全部：all 绘画：draw 摄影：photo 日常：daily 默认为 all"
+      },
+      "comment": "相簿"
+    },
     "audio": {
       "url": "https://api.bilibili.com/audio/music-service/web/song/upper",
       "method": "GET",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -15,6 +15,24 @@
       },
       "comment": "用户基本信息"
     },
+    "space_notice": {
+      "url": "http://api.bilibili.com/x/space/notice",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "mid": "int: uid"
+      },
+      "comment": "用户个人空间公告"
+    },
+    "user_tag": {
+      "url": "http://space.bilibili.com/ajax/tags/getSubList",
+      "method": "GET",
+      "verify": false,
+      "params": {
+        "mid": "int: uid"
+      },
+      "comment": "用户关注的 TAG / 话题,目前不可用，Api库无法应对重定向的，不带code字段的请求"
+    },
     "relation": {
       "url": "https://api.bilibili.com/x/relation/stat",
       "method": "GET",
@@ -274,6 +292,16 @@
         "series_id": "int: series_id",
         "aids": "int: aid 列表"
       }
+    },
+    "set_space_notice": {
+      "url": "http://api.bilibili.com/x/space/notice/set",
+      "method": "POST",
+      "verify": true,
+      "params": {
+        "notice": "str: text ,不必要",
+        "csrf": "str: CSRF Token（位于 cookie），必要"
+      },
+      "comment": "修改用户个人空间公告,目前不可用"
     },
     "del_channel_series": {
       "url": "https://api.bilibili.com/x/series/series/delete",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -313,7 +313,7 @@
         "notice": "str: text ,不必要",
         "csrf": "str: CSRF Token（位于 cookie），必要"
       },
-      "comment": "修改用户个人空间公告,目前不可用"
+      "comment": "修改用户个人空间公告"
     },
     "del_channel_series": {
       "url": "https://api.bilibili.com/x/series/series/delete",

--- a/bilibili_api/data/api/video.json
+++ b/bilibili_api/data/api/video.json
@@ -18,7 +18,7 @@
         "aid": "int: av 号",
         "bvid": "string: BV 号"
       },
-      "comment": "视频基本信息"
+      "comment": "视频详细信息"
     },
     "tags": {
       "url": "https://api.bilibili.com/x/tag/archive/tags",

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -60,6 +60,21 @@ class AudioOrder(Enum):
     FAVORITE = 3
 
 
+class DrawOrder(Enum):
+    """
+    音频排序顺序。
+
+    + PUBDATE : 上传日期倒序。
+    + FAVORITE: 收藏量倒序。
+    + VIEW    : 播放量倒序。
+    """
+
+    ALL = "all"
+    DRAW = "draw"
+    PHOTO = "photo"
+    DAILY = "daily"
+
+
 class ArticleOrder(Enum):
     """
     专栏排序顺序。
@@ -295,6 +310,28 @@ class User:
         """
         api = API["info"]["audio"]
         params = {"uid": self.__uid, "ps": ps, "pn": pn, "order": order.value}
+        return await request(
+            "GET", url=api["url"], params=params, credential=self.credential
+        )
+
+    async def get_album(
+        self, biz: DrawOrder = DrawOrder.ALL,
+        page_num: int = 1,
+        page_size: int = 30
+    ):
+        """
+        获取用户投稿音频。
+
+        Args:
+            biz (DrawOrder, optional): 排序方式. Defaults to DrawOrder.ALL.
+            page_num      (int, optional)       : 页码数，从 1 开始。 Defaults to 1.
+            page_size    (int)       : 每一页的相簿条目. Defaults to 30.
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+        api = API["info"]["album"]
+        params = {"uid": self.__uid, "page_num": page_num, "page_size": page_size, "biz": biz.value}
         return await request(
             "GET", url=api["url"], params=params, credential=self.credential
         )

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -18,7 +18,6 @@ from .utils.Credential import Credential
 from typing import List
 import httpx
 
-
 API = get_api("user")
 
 
@@ -171,6 +170,39 @@ class User:
             用户 uid
         """
         return self.__uid
+
+    async def get_space_notice(self):
+        """
+        获取用户空间公告
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+        api = API["info"]["space_notice"]
+        params = {"mid": self.__uid}
+        return await request(
+            "GET", url=api["url"], params=params, credential=self.credential
+        )
+
+    async def set_space_notice(self, content: str = ""):
+        """
+        修改用户空间公告
+
+        Args:
+            content(str): 需要修改的内容
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+
+        self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
+
+        api = API["operate"]["set_space_notice"]
+        data = {"notice": content}
+        return await request(
+            "POST", url=api["url"], data=data, credential=self.credential
+        )
 
     async def get_relation_info(self):
         """

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -60,9 +60,9 @@ class AudioOrder(Enum):
     FAVORITE = 3
 
 
-class DrawOrder(Enum):
+class AlbumType(Enum):
     """
-    音频排序顺序。
+    相册类型
 
     + ALL : 全部。
     + DRAW: 绘画。
@@ -316,7 +316,7 @@ class User:
         )
 
     async def get_album(
-        self, biz: DrawOrder = DrawOrder.ALL,
+        self, biz: AlbumType = AlbumType.ALL,
         page_num: int = 1,
         page_size: int = 30
     ):
@@ -324,7 +324,7 @@ class User:
         获取用户投稿音频。
 
         Args:
-            biz (DrawOrder, optional): 排序方式. Defaults to DrawOrder.ALL.
+            biz (AlbumType, optional): 排序方式. Defaults to AlbumType.ALL.
             page_num      (int, optional)       : 页码数，从 1 开始。 Defaults to 1.
             page_size    (int)       : 每一页的相簿条目. Defaults to 30.
 

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -64,9 +64,10 @@ class DrawOrder(Enum):
     """
     音频排序顺序。
 
-    + PUBDATE : 上传日期倒序。
-    + FAVORITE: 收藏量倒序。
-    + VIEW    : 播放量倒序。
+    + ALL : 全部。
+    + DRAW: 绘画。
+    + PHOTO    : 摄影。
+    + DAILY    : 日常。
     """
 
     ALL = "all"

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -172,13 +172,25 @@ from bilibili_api import user
 
 **Returns:** 调用接口返回的内容。
 
+#### async def get_album()
+
+| name      | type                | description                     |
+|-----------|---------------------|---------------------------------|
+| page_num  | int, optional       | 页码，从 1 开始. Defaults to 1.       |
+| page_size | int, optional       | 每一页的相簿. Defaults to 30.         |
+| biz       | DrawOrder, optional | 排序方式. Defaults to DrawOrder.ALL |
+
+获取用户投稿相簿。
+
+**Returns:** 调用接口返回的内容。
+
 #### async def get_audios()
 
-| name  | type                 | description                               |
-| ----- | -------------------- | ----------------------------------------- |
+| name  | type                 | description                           |
+|-------|----------------------|---------------------------------------|
 | order | AudioOrder, optional | 排序方式. Defaults to AudioOrder.PUBDATE. |
-| pn    | int, optional        | 页码，从 1 开始. Defaults to 1.           |
-| ps     | (int, optional)       | 每一页的视频数. Defaults to 30. |
+| pn    | int, optional        | 页码，从 1 开始. Defaults to 1.             |
+| ps    | (int, optional)      | 每一页的视频数. Defaults to 30.              |
 
 获取用户投稿音频。
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -52,6 +52,18 @@ from bilibili_api import user
 + VIEW    : 阅读量倒序。
 
 ---
+## class AlbumType
+
+**Extends:** enum.Enum
+
+相册内容类型。
+
++ ALL : 全部。
++ DRAW: 绘画。
++ PHOTO    : 摄影。
++ DAILY    : 日常。
+
+---
 
 ## class ArticleListOrder
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -178,7 +178,7 @@ from bilibili_api import user
 |-----------|---------------------|---------------------------------|
 | page_num  | int, optional       | 页码，从 1 开始. Defaults to 1.       |
 | page_size | int, optional       | 每一页的相簿. Defaults to 30.         |
-| biz       | DrawOrder, optional | 排序方式. Defaults to DrawOrder.ALL |
+| biz       | AlbumType, optional | 排序方式. Defaults to AlbumType.ALL |
 
 获取用户投稿相簿。
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -134,6 +134,12 @@ from bilibili_api import user
 
 **Returns:** 调用接口返回的内容。
 
+#### async def get_space_notice()
+
+获取用户空间公告
+
+**Returns:** 调用接口返回的内容。
+
 #### async def get_relation_info()
 
 获取用户关系信息（关注数，粉丝数，悄悄关注，黑名单数）
@@ -154,12 +160,12 @@ from bilibili_api import user
 
 #### async def get_videos()
 
-| name    | type                 | description                              |
-| ------- | -------------------- | ---------------------------------------- |
-| tid     | int, optional        | 分区 ID. Defaults to 0（全部）           |
-| pn      | int, optional        | 页码，从 1 开始. Defaults to 1.          |
-| ps      |(int, optional)       | 每一页的视频数. Defaults to 30. |
-| keyword | str, optional        | 搜索关键词. Defaults to "".              |
+| name    | type                 | description                          |
+|---------|----------------------|--------------------------------------|
+| tid     | int, optional        | 分区 ID. Defaults to 0（全部）             |
+| pn      | int, optional        | 页码，从 1 开始. Defaults to 1.            |
+| ps      | (int, optional)      | 每一页的视频数. Defaults to 30.             |
+| keyword | str, optional        | 搜索关键词. Defaults to "".               |
 | order   | VideoOrder, optional | 排序方式. Defaults to VideoOrder.PUBDATE |
 
 获取用户投稿视频信息。
@@ -180,10 +186,10 @@ from bilibili_api import user
 
 #### async def get_articles()
 
-| name  | type                   | description                                 |
-| ----- | ---------------------- | ------------------------------------------- |
+| name  | type                   | description                             |
+|-------|------------------------|-----------------------------------------|
 | order | ArticleOrder, optional | 排序方式. Defaults to ArticleOrder.PUBDATE. |
-| pn    | int, optional          | 页码，从 1 开始. Defaults to 1.             |
+| pn    | int, optional          | 页码，从 1 开始. Defaults to 1.               |
 
 获取用户投稿专栏。
 
@@ -191,11 +197,11 @@ from bilibili_api import user
 
 #### async def get_article_list()
 
-| name  | type                       | description                                   |
-| ----- | -------------------------- | --------------------------------------------- |
+| name  | type                       | description                               |
+|-------|----------------------------|-------------------------------------------|
 | order | ArticleListOrder, optional | 排序方式. Defaults to ArticleListOrder.LATEST |
-|pn    |(int, optional)         | 页码数，从 1 开始。 Defaults to 1.
-|ps     | (int, optional)       | 每一页的视频数. Defaults to 30. |
+| pn    | (int, optional)            | 页码数，从 1 开始。 Defaults to 1.                |
+| ps    | (int, optional)            | 每一页的视频数. Defaults to 30.                  |
 
 获取用户专栏文集。
 
@@ -212,11 +218,11 @@ from bilibili_api import user
 
 查看频道内所有视频。仅供 series_list。
 
-| name | type | description |
-| ---- | ---- | ----------- |
+| name | type | description                            |
+|------|------|----------------------------------------|
 | sid  | int  | 合集的 series_id (通过 get_channel_list 获取) |
-| pn   | int  | 页数，默认为1 |
-| ps   | int  | 每一页显示的视频数量，默认为100 |
+| pn   | int  | 页数，默认为1                                |
+| ps   | int  | 每一页显示的视频数量，默认为100                      |
 
 **Returns:** 调用接口返回的内容。
 
@@ -224,21 +230,21 @@ from bilibili_api import user
 
 查看频道内所有视频。仅供 season_list。
 
-| name | type | description |
-| ---- | ---- | ----------- |
-| sid  | int  | 季度 id(season_id) (通过 get_channel_list 获取) |
-| sort | ChannelOrder | 排序方式，默认为“默认排序” |
-| pn   | int  | 页数，默认为1 |
-| ps   | int  | 每一页显示的视频数量，默认为100 |
+| name | type         | description                               |
+|------|--------------|-------------------------------------------|
+| sid  | int          | 季度 id(season_id) (通过 get_channel_list 获取) |
+| sort | ChannelOrder | 排序方式，默认为“默认排序”                            |
+| pn   | int          | 页数，默认为1                                   |
+| ps   | int          | 每一页显示的视频数量，默认为100                         |
 
 **Returns:** 调用接口返回的内容。
 
 #### async def get_dynamics()
 
-| name     | type           | description                                                  |
-| -------- | -------------- | ------------------------------------------------------------ |
+| name     | type           | description                                                                                                                                          |
+|----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | offset   | str, optional  | 该值为第一次调用本方法时，数据中会有个 next_offset 字段，<br/>指向下一动态列表第一条动态（类似单向链表）。<br/>根据上一次获取结果中的 next_offset 字段值，<br/>循环填充该值即可获取到全部动态。<br/>0 为从头开始。<br/>Defaults to 0. |
-| need_top | bool, optional | 显示置顶动态. Defaults to False.                             |
+| need_top | bool, optional | 显示置顶动态. Defaults to False.                                                                                                                           |
 
 获取用户动态。
 
@@ -252,9 +258,9 @@ from bilibili_api import user
 
 #### async def get_subscribed_bangumi()
 
-| name  | type                  | description                               |
-| ----- | --------------------- | ----------------------------------------- |
-| pn    | int, optional         | 页码数，从 1 开始。 Defaults to 1.        |
+| name  | type                  | description                           |
+|-------|-----------------------|---------------------------------------|
+| pn    | int, optional         | 页码数，从 1 开始。 Defaults to 1.            |
 | type_ | BangumiType, optional | 资源类型. Defaults to BangumiType.BANGUMI |
 
 获取用户追番/追剧列表。
@@ -263,10 +269,10 @@ from bilibili_api import user
 
 #### async def get_followings()
 
-| name | type           | description                     |
-| ---- | -------------- | ------------------------------- |
+| name | type           | description               |
+|------|----------------|---------------------------|
 | pn   | int, optional  | 页码，从 1 开始. Defaults to 1. |
-| desc | bool, optional | 倒序排序. Defaults to True.     |
+| desc | bool, optional | 倒序排序. Defaults to True.   |
 
 获取用户关注列表（不是自己只能访问前5页）
 
@@ -280,15 +286,14 @@ from bilibili_api import user
 
 #### async def get_followers()
 
-| name | type           | description                     |
-| ---- | -------------- | ------------------------------- |
+| name | type           | description               |
+|------|----------------|---------------------------|
 | pn   | int, optional  | 页码，从 1 开始. Defaults to 1. |
-| desc | bool, optional | 倒序排序. Defaults to True.     |
+| desc | bool, optional | 倒序排序. Defaults to True.   |
 
 获取用户粉丝列表（不是自己只能访问前5页，是自己也不能获取全部的样子）
 
 **Returns:** 调用接口返回的内容。
-
 
 #### async def top_followers()
 
@@ -300,7 +305,6 @@ from bilibili_api import user
 
 **Returns:** 调用接口返回的内容。
 
-
 #### async def get_overview_stat()
 
 获取用户的简易订阅和投稿信息。
@@ -310,10 +314,20 @@ from bilibili_api import user
 #### async def modify_relation()
 
 | name     | type         | description |
-| -------- | ------------ | ----------- |
-| relation | RelationType | 用户关系    |
+|----------|--------------|-------------|
+| relation | RelationType | 用户关系        |
 
 修改和用户的关系，比如拉黑、关注、取关等。
+
+**Returns:** 调用接口返回的内容。
+
+#### async def set_space_notice()
+
+| name   | type | description |
+|--------|------|-------------|
+| notice | str  | 需要修改为？可以留空  |
+
+修改用户空间公告。
 
 **Returns:** 调用接口返回的内容。
 
@@ -322,8 +336,8 @@ from bilibili_api import user
 ## async def get_self_info()
 
 | name       | type       | description |
-| ---------- | ---------- | ----------- |
-| credential | Credential | 凭据        |
+|------------|------------|-------------|
+| credential | Credential | 凭据          |
 
 获取自己的信息。
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -17,8 +17,8 @@ from bilibili_api.exceptions.ResponseCodeException import ResponseCodeException
 
 UID = 660303135
 UID2 = 1033942996
-
-u = user.User(UID2, credential=credential)
+UID3 = 7949629
+u = user.User(UID3, credential=credential)
 
 
 async def test_a_User_get_user_info():
@@ -177,7 +177,15 @@ async def test_zf_get_space_notice():
     return await u.get_space_notice()
 
 
+async def test_zh_get_album():
+    return await u.get_album()
+
+
+async def test_zg_get_space_notice():
+    return await u.get_space_notice()
+
+#
 # from bilibili_api import sync
 #
-# res = sync(test_zf_get_space_notice())
+# res = sync(test_zh_get_album())
 # print(res)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,16 +3,22 @@
 import asyncio
 from re import A
 from bilibili_api import user
-from . import common
+
+try:
+    from . import common
+
+    credential = common.get_credential()
+except:
+    credential = None
+    print("导入凭据未成功")
 import time
 import random
 from bilibili_api.exceptions.ResponseCodeException import ResponseCodeException
 
-
 UID = 660303135
+UID2 = 1033942996
 
-credential = common.get_credential()
-u = user.User(UID, credential=credential)
+u = user.User(UID2, credential=credential)
 
 
 async def test_a_User_get_user_info():
@@ -165,3 +171,13 @@ async def test_ze_clean_toview_list():
 
 async def after_all():
     await u.modify_relation(user.RelationType.UNSUBSCRIBE)
+
+
+async def test_zf_get_space_notice():
+    return await u.get_space_notice()
+
+
+# from bilibili_api import sync
+#
+# res = sync(test_zf_get_space_notice())
+# print(res)


### PR DESCRIPTION
## 增加

### 增加方法 `async def get_album()`

| 参数      | type                | description                     |
|-----------|---------------------|---------------------------------|
| page_num  | int, optional       | 页码，从 1 开始. Defaults to 1.       |
| page_size | int, optional       | 每一页的相簿. Defaults to 30.         |
| biz       | AlbumType, optional | 排序方式. Defaults to AlbumType.ALL |

### 增加相簿类型枚举类 `AlbumType`

### 增加Api数据
+ album
+ space_notice
+ set_space_notice
+ user_tag(ajax)

## 新特性
获取用户投稿相簿。

## 其他

#### 关于 `user_tag` API

http://space.bilibili.com/ajax/tags/getSubList
目前不可用，因为 ajax 重定向没有被 预定的工具库处理，另外处理后也因为没有code字段不能被解析。
