### PR TITLE
[Enhancement] 增加用户关注Tag的获取方法

### DIFF
--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -135,7 +135,7 @@ class Bangumi:
     def get_episode_info(self):
         """
         如果设置了 epid,回应对应条目的条目数据
-        Returns:数据
+        Returns:数据:list
         """
         if self.__epid != -1:
             return self.ep_item

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -31,7 +31,7 @@
       "params": {
         "mid": "int: uid"
       },
-      "comment": "用户关注的 TAG / 话题"
+      "comment": "用户关注的 TAG / 话题,认证方式：SESSDATA"
     },
     "relation": {
       "url": "https://api.bilibili.com/x/relation/stat",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -31,7 +31,7 @@
       "params": {
         "mid": "int: uid"
       },
-      "comment": "用户关注的 TAG / 话题,目前不可用，Api库无法应对重定向的，不带code字段的请求"
+      "comment": "用户关注的 TAG / 话题"
     },
     "relation": {
       "url": "https://api.bilibili.com/x/relation/stat",

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -6,6 +6,7 @@ bilibili_api.user
 
 from enum import Enum
 import json
+from json.decoder import JSONDecodeError
 import time
 
 from .exceptions import ResponseCodeException
@@ -186,6 +187,38 @@ class User:
             用户 uid
         """
         return self.__uid
+
+    async def get_user_fav_tag(self):
+        """
+        获取用户关注的 Tag 信息，如果用户设为隐私，则返回 获取登录数据失败
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+
+        # (未打包至 utils 的) 获取被 ajax 重定向后的接口数据
+        api = API["info"]["user_tag"]
+        params = {"mid": self.__uid}
+        if self.credential is None:
+            cookies = Credential().get_cookies()
+        else:
+            cookies = self.credential.get_cookies()
+        # cookies["buvid3"] = str(uuid.uuid1())
+        cookies["Domain"] = ".bilibili.com"
+        sess = get_session()
+        resp = await sess.request(
+            "GET",
+            url=api["url"],
+            params=params,
+            follow_redirects=True,
+            cookies=cookies,
+            # credential=self.credential
+        )
+        try:
+            r_json = json.loads(resp.text)
+        except JSONDecodeError:
+            r_json = {'status': False, 'data': f'解析接口返回的 Json 数据失败:{resp.status_code}'}
+        return r_json
 
     async def get_space_notice(self):
         """

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -215,9 +215,12 @@ class User:
             # credential=self.credential
         )
         try:
+
             r_json = json.loads(resp.text)
         except JSONDecodeError:
             r_json = {'status': False, 'data': f'解析接口返回的 Json 数据失败:{resp.status_code}'}
+        if not r_json:
+            r_json = {'status': False, 'data': 'Failed'}
         return r_json
 
     async def get_space_notice(self):

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -195,7 +195,6 @@ class User:
         Returns:
             dict: 调用接口返回的内容。
         """
-
         # (未打包至 utils 的) 获取被 ajax 重定向后的接口数据
         api = API["info"]["user_tag"]
         params = {"mid": self.__uid}
@@ -212,13 +211,11 @@ class User:
             params=params,
             follow_redirects=True,
             cookies=cookies,
-            # credential=self.credential
         )
         try:
-
             r_json = json.loads(resp.text)
         except JSONDecodeError:
-            r_json = {'status': False, 'data': f'解析接口返回的 Json 数据失败:{resp.status_code}'}
+            r_json = {'status': False, 'data': f'解析接口返回的数据失败:{resp.status_code}'}
         if not r_json:
             r_json = {'status': False, 'data': 'Failed'}
         return r_json

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -152,6 +152,12 @@ from bilibili_api import user
 
 **Returns:** 调用接口返回的内容。
 
+#### async def get_user_fav_tag()
+
+获取用户关注的 Tag 信息，如果用户设为隐私，则返回 获取登录数据失败
+
+**Returns:** 调用接口返回的内容。
+
 #### async def get_relation_info()
 
 获取用户关系信息（关注数，粉丝数，悄悄关注，黑名单数）

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -181,11 +181,11 @@ async def test_zh_get_album():
     return await u.get_album()
 
 
-async def test_zg_get_space_notice():
-    return await u.get_space_notice()
+async def test_zg_get_user_fav_tag():
+    return await u.get_user_fav_tag()
 
-#
+
 # from bilibili_api import sync
 #
-# res = sync(test_zh_get_album())
+# res = sync(test_zg_get_user_fav_tag())
 # print(res)


### PR DESCRIPTION
## 增加

### 新增函数 `get_user_fav_tag`
```
获取用户关注的 Tag 信息，如果用户设为隐私，则返回 获取登录数据失败
Returns:
            dict: 调用接口返回的内容。
```

预览

```yaml
{'status': False, 'data': '获取登录数据失败'}
```
## 修改

### Api文档描述

### 接口描述

## 其他
`get_user_fav_tag` 的逻辑在此次 Pr 中没有打包到至 utils



#66 Issue