### PR TITLE
[Enhancement] 增加 直播类&用户类 的 拥有的粉丝勋章列表获取方法 (Web Api)

### DIFF
--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -131,7 +131,7 @@
       "method": "GET",
       "verify": false,
       "params": null,
-      "comment": "获取自己粉丝牌,大航海等数据"
+      "comment": "获取自己粉丝牌,粉丝勋章,大航海等数据"
     },
     "general_info": {
       "url": "https://api.live.bilibili.com/xlive/fuxi-interface/general/half/initial",

--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -114,6 +114,18 @@
       },
       "comment": "获取高能榜"
     },
+    "fan_model": {
+      "url": "https://api.live.bilibili.com/xlive/app-ucenter/v1/fansMedal/panel",
+      "method": "GET",
+      "verify": true,
+      "params": {
+        "roomId": "int: 房间号，不是必须的",
+        "page": "int: 页码,不是必须的",
+        "target_id": "int: 主播Uid,不是必须的",
+        "pageSize": "int: 默认 10 是必须的，否则不返回有效数据"
+      },
+      "comment": "获取房间的粉丝牌,自己的粉丝牌等数据"
+    },
     "live_info": {
       "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/live_info",
       "method": "GET",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -51,6 +51,15 @@
       },
       "comment": "视频播放量，文章阅读量，总点赞数"
     },
+    "user_medal": {
+      "url": "https://api.live.bilibili.com/xlive/web-ucenter/user/MedalWall",
+      "method": "GET",
+      "verify": true,
+      "params": {
+        "target_id": "int: uid"
+      },
+      "comment": "读取用户粉丝牌详细信息，如果隐私则不可以"
+    },
     "live": {
       "url": "https://api.bilibili.com/x/space/acc/info",
       "method": "GET",

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -198,6 +198,34 @@ class LiveRoom:
             api["method"], api["url"], params, credential=self.credential
         )
 
+    async def get_fan_model(self, page_num: int = 1, target_id: int = None, roomId: int = None):
+        """
+        获取自己的粉丝勋章信息
+
+        如果带有房间号就返回是否具有的判断 has_medal
+
+        如果带有主播 id ，就返回主播的粉丝牌，没有就返回 null
+
+        Args:
+            roomId(int, optional): 指定房间，查询是否拥有此房间的粉丝牌
+            target_id(int, optional): 指定返回一个主播的粉丝牌，留空就不返回
+            page_num(int, optional): 粉丝牌列表，默认 1
+        """
+        self.credential.raise_for_no_sessdata()
+
+        api = API["info"]["general_info"]
+        params = {
+            "pageSize": 10,
+            "page": page_num,
+        }
+        if roomId:
+            params["roomId"] = roomId
+        if target_id:
+            params["target_id"] = target_id
+        return await request(
+            api["method"], api["url"], params=params, credential=self.credential
+        )
+
     async def get_user_info_in_room(self):
         """
         获取自己在直播间的信息（粉丝勋章等级，直播用户等级等）
@@ -1024,14 +1052,14 @@ class LiveDanmaku(AsyncEvent):
             return ret
 
         while offset < len(realData):
-            header = struct.unpack(">IHHII", realData[offset : offset + 16])
+            header = struct.unpack(">IHHII", realData[offset: offset + 16])
             length = header[0]
             recvData = {
                 "protocol_version": header[2],
                 "datapack_type": header[3],
                 "data": None,
             }
-            chunkData = realData[(offset + 16) : (offset + length)]
+            chunkData = realData[(offset + 16): (offset + length)]
             if header[2] == 0:
                 recvData["data"] = json.loads(chunkData.decode())
             elif header[2] == 2:

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -213,7 +213,7 @@ class LiveRoom:
         """
         self.credential.raise_for_no_sessdata()
 
-        api = API["info"]["general_info"]
+        api = API["info"]["live_info"]
         params = {
             "pageSize": 10,
             "page": page_num,

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -1052,14 +1052,14 @@ class LiveDanmaku(AsyncEvent):
             return ret
 
         while offset < len(realData):
-            header = struct.unpack(">IHHII", realData[offset: offset + 16])
+            header = struct.unpack(">IHHII", realData[offset : offset + 16])
             length = header[0]
             recvData = {
                 "protocol_version": header[2],
                 "datapack_type": header[3],
                 "data": None,
             }
-            chunkData = realData[(offset + 16): (offset + length)]
+            chunkData = realData[(offset + 16) : (offset + length)]
             if header[2] == 0:
                 recvData["data"] = json.loads(chunkData.decode())
             elif header[2] == 2:

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -289,7 +289,7 @@ class User:
             dict: 调用接口返回的内容。
         """
         self.credential.raise_for_no_sessdata()
-        self.credential.raise_for_no_bili_jct()
+        # self.credential.raise_for_no_bili_jct()
         api = API["info"]["user_medal"]
         params = {"target_id": self.__uid}
         return await request(

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -281,6 +281,21 @@ class User:
             "GET", url=api["url"], params=params, credential=self.credential
         )
 
+    async def get_user_medal(self):
+        """
+        读取用户粉丝牌详细列表，如果隐私则不可以
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+        self.credential.raise_for_no_sessdata()
+        self.credential.raise_for_no_bili_jct()
+        api = API["info"]["user_medal"]
+        params = {"target_id": self.__uid}
+        return await request(
+            "GET", url=api["url"], params=params, credential=self.credential
+        )
+
     async def get_live_info(self):
         """
         获取用户直播间信息。

--- a/docs/modules/live.md
+++ b/docs/modules/live.md
@@ -109,6 +109,22 @@ from bilibili_api import live
 
 **Returns:** API 调用返回结果
 
+#### async def get_fan_model()
+
+| name      | type          | description         |
+|-----------|---------------|---------------------|
+| roomId    | int, optional | 指定房间，查询是否拥有此房间的粉丝牌  |
+| target_id | int, optional | 指定返回一个主播的粉丝牌，留空就不返回 |
+| page_num  | int, optional | 页码. Defaults to 1   |
+
+获取自己的粉丝勋章信息
+
+如果带有房间号就返回是否具有的判断 has_medal
+
+如果带有主播 id ，就返回主播的粉丝牌，没有就返回 null
+
+**Returns:** API 调用返回结果
+
 #### async def get_user_info_in_room()
 
 获取自己在直播间的信息（粉丝勋章等级，直播用户等级等）
@@ -155,11 +171,11 @@ from bilibili_api import live
 
 #### async def get_room_play_info_v2()
 
-| name          | type                       | description                                          |
-| ------------- | -------------------------- | ---------------------------------------------------- |
+| name          | type                       | description                                    |
+|---------------|----------------------------|------------------------------------------------|
 | live_protocol | LiveProtocol, optional     | 直播源流协议. Defaults to LiveProtocol.DEFAULT.      |
-| live_format   | LiveFormat, optional       | 直播源容器格式. Defaults to LiveFormat.DEFAULT.      |
-| live_codec    | LiveCodec, optional        | 直播源视频编码. Defaults to LiveCodec.DEFAULT.       |
+| live_format   | LiveFormat, optional       | 直播源容器格式. Defaults to LiveFormat.DEFAULT.       |
+| live_codec    | LiveCodec, optional        | 直播源视频编码. Defaults to LiveCodec.DEFAULT.        |
 | live_qn       | ScreenResolution, optional | 直播源清晰度. Defaults to ScreenResolution.ORIGINAL. |
 
 获取房间信息及可用清晰度列表
@@ -186,7 +202,7 @@ from bilibili_api import live
 
 | name   | type | description                           |
 | ------ | ---- | ------------------------------------- |
-| tab_id | int  | 礼物类型.   2：特权礼物， 3：定制礼物 |
+| tab_id | int  | 礼物类型. 2：特权礼物， 3：定制礼物 |
 
 获取当前直播间内的特殊礼物列表
 
@@ -411,11 +427,11 @@ Websocket 实时获取直播弹幕
 | area_id        | int, optional | 子分区 ID. Defaults to None   |
 | area_parent_id | int, optional | 父分区 ID. Defaults to None   |
 
-  获取所有礼物的信息，包括礼物 ID、名称、价格、等级等。
+获取所有礼物的信息，包括礼物 ID、名称、价格、等级等。
 
-  同时填了 `room_id`、`area_id`、`area_parent_id`，则返回一个较小的 json，只包含该房间、该子区域、父区域的礼物。
+同时填了 `room_id`、`area_id`、`area_parent_id`，则返回一个较小的 json，只包含该房间、该子区域、父区域的礼物。
 
-  但即使限定了三个条件，仍然会返回约 1.5w 行的 json。不加限定则是 2.8w 行。
+但即使限定了三个条件，仍然会返回约 1.5w 行的 json。不加限定则是 2.8w 行。
 
 **Returns:** API 调用返回结果
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -52,6 +52,7 @@ from bilibili_api import user
 + VIEW    : 阅读量倒序。
 
 ---
+
 ## class AlbumType
 
 **Extends:** enum.Enum
@@ -167,6 +168,12 @@ from bilibili_api import user
 #### async def get_up_stat()
 
 获取 UP 主数据信息（视频总播放量，文章总阅读量，总点赞数）
+
+**Returns:** 调用接口返回的内容。
+
+#### async def get_user_medal()
+
+读取用户粉丝牌详细列表，如果隐私则不可以,需要登录状态，返回的数据带有 查询者的 uid
 
 **Returns:** 调用接口返回的内容。
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -18,7 +18,9 @@ from bilibili_api.exceptions.ResponseCodeException import ResponseCodeException
 UID = 660303135
 UID2 = 1033942996
 UID3 = 7949629
-u = user.User(UID3, credential=credential)
+UID_Model_Test = 12344667
+
+u = user.User(UID_Model_Test, credential=credential)
 
 
 async def test_a_User_get_user_info():
@@ -185,7 +187,11 @@ async def test_zg_get_user_fav_tag():
     return await u.get_user_fav_tag()
 
 
+async def test_zg_get_user_medal():
+    return await u.get_user_medal()
+
+
 # from bilibili_api import sync
 #
-# res = sync(test_zg_get_user_fav_tag())
+# res = sync(test_zg_get_user_medal())
 # print(res)


### PR DESCRIPTION
## 增加

###  `async def get_user_medal` 方法

```
        读取用户粉丝牌详细列表，如果隐私则不可以

        Returns:
            dict: 调用接口返回的内容。
```

###  `async def get_fan_model` 方法

```
Args:
            roomId(int, optional): 指定房间，查询是否拥有此房间的粉丝牌
            target_id(int, optional): 指定返回一个主播的粉丝牌，留空就不返回
            page_num(int, optional): 粉丝牌列表，默认 1
       
```

## 描述

获取用户拥有的粉丝牌列表
接口对应为 主页，直播间

## 其它

+ 增加文档

+ 增加部分例子
**此改动需要额外测试**

+ 增加 Api 数据

