### PR TITLE
fix: 修正了短链接解析未按预期工作的问题

### DIFF
--- a/bilibili_api/utils/short.py
+++ b/bilibili_api/utils/short.py
@@ -14,20 +14,22 @@ async def get_real_url(short_url: str):
     Returns:
         目标链接（如果不是有效的链接会报错）
     """
+    config = {}
+    config["method"] = "GET"
+    config["url"] = short_url
+    config["follow_redirects"] = False
+    if settings.proxy:
+        config["proxies"] = {settings.proxy_use: settings.proxy}
     try:
-        url = short_url
-        headers = await get_headers(url)
-        while "location" in headers.keys():
-            url = headers["location"]
-            headers = await get_headers(url)
-        return url  # 已经是最终路径
+        resp = await get_session().head(url=short_url, follow_redirects=True)
+        return resp.url
     except Exception as e:
         raise e
 
 
 async def get_headers(short_url: str):
     """
-    获取链接的 headers
+    获取链接的 headers。
     """
     config = {}
     config["method"] = "GET"


### PR DESCRIPTION
## Issue

`get_real_url` failed to parse video share shortlink correctly. The stack trace is attached below.

```
>>> B.sync(B.get_real_url("https://b23.tv/JiaCLnr"))
https://b23.tv/JiaCLnr
https://www.bilibili.com/video/BV1QB4y1J78L?is_story_h5=false&p=1&share_from=ugc&share_medium=android&share_plat=android&share_session_id=17da308a-057c-4f77-949a-abfd18648354&share_source=COPY&share_tag=s_i&timestamp=1664246722&unique_k=JiaCLnr
/video/BV1QB4y1J78L/?is_story_h5=false&p=1&share_from=ugc&share_medium=android&share_plat=android&share_session_id=17da308a-057c-4f77-949a-abfd18648354&share_source=COPY&share_tag=s_i&timestamp=1664246722&unique_k=JiaCLnr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kun/.local/lib/python3.10/site-packages/bilibili_api/utils/sync.py", line 26, in sync
    return loop.run_until_complete(coroutine)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/kun/.local/lib/python3.10/site-packages/bilibili_api/utils/short.py", line 25, in get_real_url
    raise e
  File "/home/kun/.local/lib/python3.10/site-packages/bilibili_api/utils/short.py", line 22, in get_real_url
    headers = await get_headers(url)
  File "/home/kun/.local/lib/python3.10/site-packages/bilibili_api/utils/short.py", line 39, in get_headers
    resp = await get_session().head(url=short_url, follow_redirects=False)
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_client.py", line 1809, in head
    return await self.request(
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_client.py", line 1514, in request
    request = self.build_request(
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_client.py", line 356, in build_request
    return Request(
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_models.py", line 333, in __init__
    Cookies(cookies).set_cookie_header(self)
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_models.py", line 1031, in set_cookie_header
    urllib_request = self._CookieCompatRequest(request)
  File "/home/kun/.local/lib/python3.10/site-packages/httpx/_models.py", line 1169, in __init__
    super().__init__(
  File "/usr/lib/python3.10/urllib/request.py", line 322, in __init__
    self.full_url = url
  File "/usr/lib/python3.10/urllib/request.py", line 348, in full_url
    self._parse()
  File "/usr/lib/python3.10/urllib/request.py", line 377, in _parse
    raise ValueError("unknown url type: %r" % self.full_url)
ValueError: unknown url type: '/video/BV1QB4y1J78L/?is_story_h5=false&p=1&share_from=ugc&share_medium=android&share_plat=android&share_session_id=17da308a-057c-4f77-949a-abfd18648354&share_source=COPY&share_tag=s_i&timestamp=1664246722&unique_k=JiaCLnr'
>>> 
```

Bilibili redirects to a relative URL instead of an absolute one. The missing hostname caused the error.

## My Fix

The original `get_real_url` attempted to mock the process of a client following redirects, a feature implemented in `httpx`. I fixed it by using `httpx`-native calls to fetch the long URL back.

I also removed the unecessary `print`'s.

## Code Coverage

- Other functions that depends on `get_real_url` have not been tested to work properly. (For example [`parse_link`](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/utils/parse_link.py) may or may not work as expected.)
- Short links other than video and audio haven't been tested.
- Function [`get_headers`](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/utils/short.py) should now be obsolete.
