### PR TITLE
search_by_type接口搜索10分钟以下时长视频duration值应为1

### DIFF
--- a/bilibili_api/search.py
+++ b/bilibili_api/search.py
@@ -202,7 +202,7 @@ async def search_by_type(
         elif 10 < time_range <= 30:
             time_code = 2
         elif 0 < time_range <= 10:
-            time_code = 2
+            time_code = 1
         else:
             time_code = 0
         params["duration"] = time_code


### PR DESCRIPTION
`bilibili_api/search.py` 中 `search_by_type()` 方法，当搜索10分钟以下时长视频时，接口参数的正确duration值应为1。（如图所示
盲猜应该是写代码时复制的上一行，不小心没改过来~(dog

<img width="1454" alt="image" src="https://user-images.githubusercontent.com/20333663/204440758-ea886ee5-aa44-4b1a-a150-57bc69856d7e.png">

# 更改
- 1. {修复} search_by_type接口duration参数值的错误



