### PR TITLE
session.py 适配新 Picture 类

### DIFF
--- a/bilibili_api/data/api/session.json
+++ b/bilibili_api/data/api/session.json
@@ -50,11 +50,9 @@
           "msg[sender_uid]": "int: 自己的 UID",
           "msg[receiver_id]": "int: 对方 UID",
           "msg[receiver_type]": "const int: 1",
-          "msg[msg_type]": "const int: 1",
+          "msg[msg_type]": "int: 消息类型",
           "msg[msg_status]": "const int: 0",
-          "msg[content]": {
-            "content": "str: 文本内容"
-          }
+          "msg[content]": "str: 消息内容"
         },
         "comment": "给用户发信息"
       }

--- a/bilibili_api/utils/Picture.py
+++ b/bilibili_api/utils/Picture.py
@@ -56,6 +56,15 @@ class Picture:
         self.url = "file://" + path
         self.__set_picture_meta_from_bytes(os.path.basename(path).split(".")[1])
         return self
+    
+    async def upload_file(self, path: str, credential: Credential) -> "Picture":
+        from ..dynamic import upload_image
+        self.from_file(path)
+        res = await upload_image(self, credential)
+        self.height = res["image_height"]
+        self.width = res["image_width"]
+        self.url = res["image_url"]
+        return self
 
     def convert_format(self, new_format: str) -> None:
         tmp_dir = tempfile.gettempdir()

--- a/bilibili_api/utils/Picture.py
+++ b/bilibili_api/utils/Picture.py
@@ -4,6 +4,7 @@ from typing import Any
 import tempfile
 import os
 import httpx
+from .Credential import Credential
 
 
 @dataclass

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -3,19 +3,24 @@
 ```python
 from bilibili_api import Credential, sync
 from bilibili_api.session import Session, Event
+from bilibili_api.utils.Picture import Picture
 
 session = Session(Credential(...))
 
 @session.on(Event.PICTURE)
 async def pic(event: Event):
-    await event.content.download()
+    img: Picture = event.content
+    img.download("./")
 
 @session.on(Event.TEXT)
 async def reply(event: Event):
-    if event.content == '/close':
+    if event.content == "/close":
         session.close()
+    elif event.content == "来张涩图":
+        img = await Picture().upload_file("test.png", session.credential)
+        await session.reply(event, img)
     else:
-        await session.reply(event, '你好李鑫')
+        await session.reply(event, "你好李鑫")
 
 sync(session.start())
 ```

--- a/docs/modules/session.md
+++ b/docs/modules/session.md
@@ -43,13 +43,14 @@ from bilibili_api import session
 
 #### async def send_msg()
 
-| name        | type       | description |
-| ----------- | ---------- | ----------- |
-| credential  | Credential | 凭证        |
-| receiver_id | int        | 接收者 UID  |
-| text        | str        | 信息内容。  |
+| name        | type          | description |
+| ----------- | ------------- | ----------- |
+| credential  | Credential    | 凭证        |
+| receiver_id | int           | 接收者 UID  |
+| msg_type    | str           | 信息类型    |
+| content     | str 或 Picture | 信息内容。  |
 
-给用户发送私聊信息。目前仅支持纯文本。
+给用户发送私聊信息。目前支持纯文本、图片、撤回。
 
 **Returns:** dict: 调用 API 返回结果
 
@@ -188,10 +189,10 @@ from bilibili_api import session
 
 #### async def reply()
 
-| name  | type  | description |
-| ----- | ----- | ----------- |
-| event | Event | 要回复的消息 |
-| text  | str   | 回复文字     |
+| name    | type  | description |
+| ------- | ----- | ----------- |
+| event   | Event | 要回复的消息 |
+| content | str 或 Picture | 回复文字或图片 |
 
 快速回复
 


### PR DESCRIPTION
现在 ```session.py``` 已经适配新 ```Picture``` 类 (#130)
实现了发送图片消息，因此原先参数 ```text``` 已更名为更合适的 ```content```。
同时 ```send_msg()``` 新增必要参数 ```msg_type``` 用于区分要发送消息的类型。
新增了一个 ```Picture``` 类的上传函数 ```upload_file()``` 具体描述见 commit。
