### PR TITLE
update video_zone.json

### DIFF
--- a/bilibili_api/data/video_zone.json
+++ b/bilibili_api/data/video_zone.json
@@ -713,6 +713,13 @@
         "url": "//www.bilibili.com/v/life/funny"
       },
       {
+        "subChannelId": 160008,
+        "name": "亲子",
+        "route": "parenting",
+        "tid": 254,
+        "url": "//www.bilibili.com/v/life/parenting"
+      },
+      {
         "subChannelId": 160006,
         "name": "出行",
         "route": "travel",
@@ -924,11 +931,11 @@
         "url": "//www.bilibili.com/v/animal/dog"
       },
       {
-        "subChannelId": 180003,
-        "name": "大熊猫",
-        "route": "panda",
-        "tid": 220,
-        "url": "//www.bilibili.com/v/animal/panda"
+        "subChannelId": 180007,
+        "name": "小宠异宠",
+        "route": "reptiles",
+        "tid": 222,
+        "url": "//www.bilibili.com/v/animal/reptiles"
       },
       {
         "subChannelId": 180004,
@@ -938,11 +945,11 @@
         "url": "//www.bilibili.com/v/animal/wild_animal"
       },
       {
-        "subChannelId": 180005,
-        "name": "爬宠",
-        "route": "reptiles",
-        "tid": 222,
-        "url": "//www.bilibili.com/v/animal/reptiles"
+        "subChannelId": 180008,
+        "name": "动物二创",
+        "route": "second_edition",
+        "tid": 220,
+        "url": "//www.bilibili.com/v/animal/second_edition"
       },
       {
         "subChannelId": 180006,


### PR DESCRIPTION
显然是从 https://s1.hdslb.com/bfs/seed/laputa-header/bili-header.umd.js 获取的更新
但是里面似乎还是不全...
比如 [纪录片信息](https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/video/video_zone.md#%E7%BA%AA%E5%BD%95%E7%89%87) 其实还能找到纪录片的 SubChannnel，但我找不到 ChannelId 所以暂时作罢...不知道有啥看法？
tid 254 222 220 的更新
~~扒的 JS 里面似乎还有新能源汽车的 tid 的更新写着246，但我测试了好像不太对，还是247，没动~~
![image](https://user-images.githubusercontent.com/78744121/214344770-af9de9e2-ac51-4c00-b01f-b9443e2847f6.png)
![image](https://user-images.githubusercontent.com/78744121/214344941-a6209f2a-9184-419c-8ea3-6e52046b5303.png)
![image](https://user-images.githubusercontent.com/78744121/214345001-d0233797-3fca-4caa-a9f1-2a6a6241ec53.png)
