### PR TITLE
fix: github action warning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

修复 github action 警告：在 `actions/setup-python@v3` 版本使用了即将被弃用的命令 `set-output`

<!-- 请向 dev 分支发起 pull request-->
