### PR TITLE
Fix upload chunk timeout issue and upload cover image url key issue

### DIFF
--- a/bilibili_api/video_uploader.py
+++ b/bilibili_api/video_uploader.py
@@ -8,6 +8,7 @@ from asyncio.exceptions import CancelledError
 from asyncio.tasks import Task, create_task
 import os
 import time
+import random
 
 from .video import Video
 from .utils.aid_bvid_transformer import bvid2aid
@@ -466,8 +467,9 @@ class VideoUploader(AsyncEvent):
                 else Picture().from_file(self.cover_path)
             )
             resp = await _upload_cover(pic, self.credential)
-            self.dispatch(VideoUploaderEvents.AFTER_COVER.value, {"url": resp["url"]})
-            return resp["image_url"]
+            self.dispatch(VideoUploaderEvents.AFTER_COVER.value,
+                          {"url": resp["url"]})
+            return resp["url"]
         except Exception as e:
             self.dispatch(VideoUploaderEvents.COVER_FAILED.value, {"err": e})
             raise e
@@ -537,7 +539,7 @@ class VideoUploader(AsyncEvent):
         # 上传目标 URL
         return (
             "https:"
-            + preupload["endpoint"]
+            + random.choice(preupload["endpoints"])
             + "/"
             + preupload["upos_uri"].removeprefix("upos://")
         )
@@ -904,7 +906,7 @@ class VideoEditor(AsyncEvent):
             )
             resp = await _upload_cover(pic, self.credential)
             self.dispatch(VideoEditorEvents.AFTER_COVER.value, {"url": resp["url"]})
-            self.meta["cover"] = resp["image_url"]
+            self.meta["cover"] = resp["image_url"]  # not sure if this key changed to "url" as well
         except Exception as e:
             self.dispatch(VideoEditorEvents.COVER_FAILED.value, {"err": e})
             raise e


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# {请说明更改}
- 1. {新增} None
- 2. {修复} fixed upload video chunk timeout issue and upload cover image key issue
 I think some of the cdn server are not reliable. preupload has a list of endpoints, so I added a random choice to try all endpoints at each retry.

timeout, issue
```
{'name': 'PREUPLOAD', 'data': ({<bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>: <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>},)}
{'name': 'PRE_PAGE', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>, 'offset': 10485760, 'chunk_number': 1, 'total_chunk_count': 3},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>, 'offset': 20971520, 'chunk_number': 2, 'total_chunk_count': 3},)}

{'name': 'CHUNK_FAILED', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3, 'info': ''},)}

{'name': 'CHUNK_FAILED', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f01935f8760>, 'offset': 20971520, 'chunk_number': 2, 'total_chunk_count': 3, 'info': ''},)}
```

upload cover image key issue

```
{'name': 'COVER_FAILED', 'data': ({'err': KeyError('image_url')},)}
{'name': 'FAILED', 'data': ({'err': KeyError('image_url')},)}
Traceback (most recent call last):
  File "/home/harry/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/harry/.pyenv/versions/3.10.4/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/harry/.vscode-server/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/home/harry/Downloads/bilibili-api/test.py", line 68, in <module>
    sync(upload_video(f'{dir_path}/2023-03-08.mp4', 'test title'))
  File "/home/harry/Downloads/bilibili-api/bilibili_api/utils/sync.py", line 33, in sync
    return loop.run_until_complete(coroutine)
  File "/home/harry/.pyenv/versions/3.10.4/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/harry/Downloads/bilibili-api/test.py", line 62, in upload_video
    await uploader.start()
  File "/home/harry/Downloads/bilibili-api/bilibili_api/video_uploader.py", line 457, in start
    raise e
  File "/home/harry/Downloads/bilibili-api/bilibili_api/video_uploader.py", line 449, in start
    result = await task
  File "/home/harry/Downloads/bilibili-api/bilibili_api/video_uploader.py", line 430, in _main
    cover_url = await self._upload_cover()
  File "/home/harry/Downloads/bilibili-api/bilibili_api/video_uploader.py", line 479, in _upload_cover
    raise e
  File "/home/harry/Downloads/bilibili-api/bilibili_api/video_uploader.py", line 476, in _upload_cover
    return resp["image_url"]
KeyError: 'image_url'
```

After fix

```
-> % python test.py                                                                                                                                                                                                                                                                 
Uploading [/home/harry/Downloads/bilibili-api/2023-03-08.mp4] with title [test title]
metadata: [{'act_reserve_create': 0, 'copyright': 1, 'source': '', 'desc': '', 'desc_format_id': 0, 'dynamic': '', 'interactive': 0, 'no_reprint': 1, 'open_elec': 0, 'origin_state': 0, 'subtitles': {'lan': '', 'open': 0}, 'tag': '周杰伦', 'tid': 137, 'title': 'test title', 'up_close_danmaku': False, 'up_close_reply': False, 'up_selection_reply': False}]
{'name': 'PREUPLOAD', 'data': ({<bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>: <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>},)}
{'name': 'PRE_PAGE', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 10485760, 'chunk_number': 1, 'total_chunk_count': 3},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 20971520, 'chunk_number': 2, 'total_chunk_count': 3},)}
{'name': 'AFTER_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 20971520, 'chunk_number': 2, 'total_chunk_count': 3},)}
{'name': 'AFTER_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 10485760, 'chunk_number': 1, 'total_chunk_count': 3},)}

{'name': 'CHUNK_FAILED', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3, 'info': ''},)}
{'name': 'PRE_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3},)}
{'name': 'AFTER_CHUNK', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>, 'offset': 0, 'chunk_number': 0, 'total_chunk_count': 3},)}
{'name': 'PRE_PAGE_SUBMIT', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>},)}
{'name': 'AFTER_PAGE_SUBMIT', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>},)}
{'name': 'AFTER_PAGE', 'data': ({'page': <bilibili_api.video_uploader.VideoUploaderPage object at 0x7f395cfeaef0>},)}
{'name': 'PRE_COVER', 'data': (None,)}
{'name': 'AFTER_COVER', 'data': ({'url': 'https://archive.biliimg.com/bfs/archive/dee6dfba8f11759e5d0d4ea4109ebfd31d85c6d3.png'},)}
{'name': 'PRE_SUBMIT', 'data': ({'act_reserve_create': 0, 'copyright': 1, 'source': '', 'desc': '', 'desc_format_id': 0, 'dynamic': '', 'interactive': 0, 'no_reprint': 1, 'open_elec': 0, 'origin_state': 0, 'subtitles': {'lan': '', 'open': 0}, 'tag': '周杰伦', 'tid': 137, 'title': 'test title', 'up_close_danmaku': False, 'up_close_reply': False, 'up_selection_reply': False, 'cover': 'https://archive.biliimg.com/bfs/archive/dee6dfba8f11759e5d0d4ea4109ebfd31d85c6d3.png', 'videos': [{'title': 'test title', 'desc': 'test title', 'filename': 'n230311a23qj8w1k9g8jvt2qa8yawrhq', 'cid': 1047682118}]},)}
{'name': 'AFTER_SUBMIT', 'data': ({'aid': 225838846, 'bvid': 'BV1Db411f7oi'},)}
{'name': 'COMPLETE', 'data': ({'aid': 225838846, 'bvid': 'BV1Db411f7oi'},)}

```

- 3. {其他}

<!-- 请向 dev 分支发起 pull request-->
