### PR TITLE
获取指定tag下的后面的视频/动态

### DIFF
--- a/bilibili_api/data/api/video_tag.json
+++ b/bilibili_api/data/api/video_tag.json
@@ -25,6 +25,15 @@
         "topic_id": "int: 标签 id"
       },
       "comment": "获取相关的动态/视频"
+    },
+    "get_history_list": {
+      "url": "https://api.vc.bilibili.com/topic_svr/v1/topic_svr/topic_history",
+      "method": "GET",
+      "params": {
+        "topic_id": "int: 标签 id",
+        "offset_dynamic_id": "int: 起始视频/动态的dynamic_id(不包含自身)"
+      },
+      "comment": "获取从指定dynamic_id视频的后一位开始的相关的动态/视频, 先用get_list获取dynamic_id。"
     }
   }
 }

--- a/bilibili_api/video_tag.py
+++ b/bilibili_api/video_tag.py
@@ -81,6 +81,15 @@ class Tag:
         api = API["info"]["get_list"]
         params = {"topic_id": self.get_tag_id()}
         return await request("GET", api["url"], params=params)
+    async def get_history_cards(self,offset_dynamic_id:int)-> dict:
+        """
+        获取标签下，指定dynamic_id的视频的后一个视频/动态作为起始的视频/动态
+        Returns:
+            dict: 调用 API 返回的结果
+        """
+        api = API["info"]["get_history_list"]
+        params = {"topic_id": self.get_tag_id(), "offset_dynamic_id": offset_dynamic_id}
+        return await request("GET", api["url"], params=params)
 
     async def subscribe_tag(self) -> dict:
         """

--- a/docs/examples/video_tag.md
+++ b/docs/examples/video_tag.md
@@ -5,3 +5,19 @@ from bilibili_api import video_tag, sync
 tag = video_tag.Tag(tag_name="空难")
 print(sync(tag.get_cards()))
 ```
+
+``` python
+# 获取从第二个视频开始的视频/动态
+from bilibili_api import video_tag, sync
+tag = video_tag.Tag(tag_name="空难")
+
+cards = sync(tag.get_cards())["cards"]
+
+first_di = cards[0]["desc"]["dynamic_id"]
+second_di = cards[1]["desc"]["dynamic_id"]
+
+# tag.get_history_cards 得到的是以指定dynamic_id的视频/动态的*后一个视频/动态*作为起始的cards
+history_cards = sync(tag.get_history_cards(first_di))["cards"]
+
+assert second_di == history_cards[0]["desc"]["dynamic_id"]
+```

--- a/tests/test_video_tag.py
+++ b/tests/test_video_tag.py
@@ -22,3 +22,8 @@ async def test_d_subscribe_tag():
 
 async def test_e_unsubscribe_tag():
     return await tag.unsubscribe_tag()
+
+
+async def test_f_get_history_cards():
+    first_offset_dynamic_id = (await tag.get_cards())["cards"][0]["desc"]["dynamic_id"] # tag下第一个视频/动态的dynamic id
+    return await tag.get_history_cards(offset_dynamic_id=first_offset_dynamic_id)


### PR DESCRIPTION
get_card() 只能获取最顶部的几个视频，后面的一些视频就不能获取了。

通过https://api.vc.bilibili.com/topic_svr/v1/topic_svr/topic_history，传入offset_dynamic_id，可以依此方法获取指定dynamic_id的视频后开始的视频。
