### PR TITLE
debug 直播弹幕获取不到

### DIFF
--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -908,7 +908,7 @@ class LiveDanmaku(AsyncEvent):
             self.logger.info(f"正在尝试连接主机： {uri}")
 
             try:
-                async with session.ws_connect(uri) as ws:
+                async with session.ws_connect(uri, headers={"User-Agent": "Mozilla/5.0"}) as ws:
 
                     @self.on("VERIFICATION_SUCCESSFUL")
                     async def on_verification_successful(data):

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -21,7 +21,7 @@ from .utils.danmaku import Danmaku
 from .utils.network import get_session
 from .utils.AsyncEvent import AsyncEvent
 from .utils.credential import Credential
-from .utils.network_httpx import Api
+from .utils.network_httpx import Api, HEADERS
 from .exceptions.LiveException import LiveException
 
 API = get_api("live")
@@ -908,7 +908,7 @@ class LiveDanmaku(AsyncEvent):
             self.logger.info(f"正在尝试连接主机： {uri}")
 
             try:
-                async with session.ws_connect(uri, headers={"User-Agent": "Mozilla/5.0"}) as ws:
+                async with session.ws_connect(uri, headers=HEADERS) as ws:
 
                     @self.on("VERIFICATION_SUCCESSFUL")
                     async def on_verification_successful(data):


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->
`直播弹幕获取不到（除了头两次连接后），对比blivedm源码，发现ws_connect增加header可以解决。怀疑服务器加了简单过滤。
# {请说明更改}

- 2. {修复}


<!-- 请向 dev 分支发起 pull request-->
