### PR TITLE
feat: bilibili-api-dev 库自动发布

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - name: Export branch and version
+      run: echo "${{ github.ref_name }}|${{ github.event.release.target_commitish }}" > github.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,15 @@ import setuptools
 with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
 
-with open("requirements.txt", "r", encoding="utf8") as f:
+with open("requirements.txt", "r", encoding="utf-8") as f:
     requires = f.read()
 
+with open("github.txt", "r", encoding="utf-8") as f:
+    cfg = f.read().split("|")
+
 setuptools.setup(
-    name="bilibili-api-python",
-    version="16.0.0",
+    name="bilibili-api-python" if "dev" not in cfg[1] else "bilibili-api-dev",
+    version=cfg[0],
     license="GPLv3+",
     author="Nemo2011",
     author_email="yimoxia@outlook.com",


### PR DESCRIPTION
- 需要在 `dev` 分支发布 `release`
- 现在会自动把发布 `release` 时的 `tag` 作为 `setup.py` 中的 `version`
- `tag` 推荐使用 PyPI 的版本规则 [PEP 440](https://peps.python.org/pep-0440/#pre-releases) 形如 `X.Y.ZbN` 例 `16.0.1b1`
- 但是也可以使用 [语义化版本](https://semver.org/lang/zh-CN/) 中的规则 `16.0.1-beta.1`，会被自动转换成上版本号
