### PR TITLE
fix: 修复获取弹幕时发生的异常

### DIFF
--- a/bilibili_api/ass.py
+++ b/bilibili_api/ass.py
@@ -193,7 +193,7 @@ async def make_ass_file_danmakus_protobuf(
                 if page is None:
                     raise ArgsException("page_index 和 cid 至少提供一个。")
                 # type: ignore
-                cid = await v._Video__get_page_id_by_index(page)
+                cid = await v._Video__get_cid_by_index(page)
         try:
             info = await v.get_info()
         except:
@@ -274,7 +274,7 @@ async def make_ass_file_danmakus_xml(
             if cid is None:
                 if page is None:
                     raise ArgsException("page_index 和 cid 至少提供一个。")
-                cid = await v._Video__get_page_id_by_index(page)  # type: ignore
+                cid = await v._Video__get_cid_by_index(page)  # type: ignore
         try:
             info = await v.get_info()
         except:


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# 修复获取弹幕时发生的异常
- 1. {新增}
- 2. {修复}
  修复获取弹幕时发生的异常
- 3. {其他}

<!-- 请向 dev 分支发起 pull request-->

在 https://github.com/Nemo2011/bilibili-api/commit/f6ec0aa573a922d7d69619739606651d93b69769 提交中将 `__get_page_id_by_index` 更名为了 `__get_cid_by_index`，IDE 会自动对所有引用进行重命名，但由于此处在类外调用隐藏方法用了[名称改写](https://www.geeksforgeeks.org/name-mangling-in-python/)，导致 IDE 没有识别到，进而引发了函数不存在的异常。