### PR TITLE
Implement get_media_list() in User

### DIFF
--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -126,6 +126,26 @@
       },
       "comment": "搜索用户视频"
     },
+    "media_list": {
+      "url": "https://api.bilibili.com/x/v2/medialist/resource/list",
+      "method": "GET",
+      "verify": false,
+      "wbi": true,
+      "params": {
+        "mobi_app": "str: 未知",
+        "type": "int: 未知， 必填",
+        "biz_id": "int: uid",
+        "oid": "int: 未知",
+        "otype": "int: 未知",
+        "ps": "int: 每页视频数量， 最大为100",
+        "direction": "bool: 未知",
+        "desc": "bool: 是否逆序排列",
+        "sort_field": "int: 用于排序的栏 1 发布时间，2 播放量，3 收藏量",
+        "tid": "int: 分区 ID，0 表示全部",
+        "with_current": "bool: 未知"
+      },
+      "comment": "以medialist形式获取用户视频列表"
+    },
     "reservation": {
       "url": "https://api.bilibili.com/x/space/reservation",
       "method": "GET",

--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -132,17 +132,17 @@
       "verify": false,
       "wbi": true,
       "params": {
-        "mobi_app": "str: 未知",
-        "type": "int: 未知， 必填",
+        "mobi_app": "str: 定值 web",
+        "type": "int: 视频类型，通过uid获取用户视频时为1",
         "biz_id": "int: uid",
-        "oid": "int: 未知",
-        "otype": "int: 未知",
+        "oid": "int: 起始视频 aid， 默认为列表开头",
+        "otype": "int: oid类型， 接受任意值不影响结果",
         "ps": "int: 每页视频数量， 最大为100",
-        "direction": "bool: 未知",
-        "desc": "bool: 是否逆序排列",
+        "direction": "bool: 相对于给定oid的查询方向，true：向列表末尾方向，false：向列表开头方向",
+        "desc": "bool: 列表是否逆序排列",
         "sort_field": "int: 用于排序的栏 1 发布时间，2 播放量，3 收藏量",
-        "tid": "int: 分区 ID，0 表示全部",
-        "with_current": "bool: 未知"
+        "tid": "int: 分区 ID，0 表示全部， 1 部分（未知），不接受2及以上",
+        "with_current": "bool: 返回的列表中是否包含给定oid自身"
       },
       "comment": "以medialist形式获取用户视频列表"
     },

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -38,8 +38,8 @@ class MedialistOrder(Enum):
     medialist排序顺序。
 
     + PUBDATE : 上传日期。
-    + COLLECT : 收藏量。
     + PLAY    : 播放量。
+    + COLLECT : 收藏量。
     """
 
     PUBDATE = 1
@@ -444,10 +444,7 @@ class User:
 
     async def get_media_list(
         self,
-        mobi_app: str = 'web',
-        type_: int = 1,
         oid: int|None = None,
-        otype: int = 2,
         ps: int = 20,
         direction: bool = False,
         desc: bool = True,
@@ -459,27 +456,24 @@ class User:
         以 medialist 形式获取用户投稿信息。
 
         Args:
-            mobi_app        (str, optional)         : 未知
-            type_           (int)                   : 未知
-            oid             (int, optional)         : 未知
-            otype           (int, optional)         : 未知
-            ps              (int, optional)         : 每一页的番剧数. Defaults to 20. Max 100
-            direction       (bool, optional)        : 未知
+            oid             (int, optional)         : 起始视频 aid， 默认为列表开头
+            ps              (int, optional)         : 每一页的视频数. Defaults to 20. Max 100
+            direction       (bool, optional)        : 相对于给定oid的查询方向 True 向列表末尾方向 False 向列表开头方向 Defaults to False.
             desc            (bool, optional)        : 倒序排序. Defaults to True.
-            sort_field      (int, optional)         : 用于排序的栏  1 发布时间， 2 播放量
-            tid             (int, optional)         : 分区 ID. Defaults to 0（全部）.
-            with_current    (bool, optional)        : 未知
+            sort_field      (int, optional)         : 用于排序的栏  1 发布时间，2 播放量，3 收藏量
+            tid             (int, optional)         : 分区 ID. Defaults to 0（全部）. 1 部分（未知）
+            with_current    (bool, optional)        : 返回的列表中是否包含给定oid自身 Defaults to False.
 
         Returns:
             dict: 调用接口返回的内容。
         """
         api = API["info"]["media_list"]
         params = {
-            "mobi_app": mobi_app,
-            "type": type_,
+            "mobi_app": 'web',
+            "type": 1,
             "biz_id": self.__uid,
             "oid": oid,
-            "otype": otype,
+            "otype": 2,
             "ps": ps,
             "direction": direction,
             "desc": desc,

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -33,6 +33,20 @@ class VideoOrder(Enum):
     VIEW = "click"
 
 
+class MedialistOrder(Enum):
+    """
+    medialist排序顺序。
+
+    + PUBDATE : 上传日期倒序。
+    + COLLECT : 收藏量倒序。
+    + VIEW    : 播放量倒序。
+    """
+
+    PUBDATE = 1
+    VIEW = 2
+    COLLECT = 3
+
+
 class AudioOrder(Enum):
     """
     音频排序顺序。
@@ -423,6 +437,55 @@ class User:
             "pn": pn,
             "keyword": keyword,
             "order": order.value,
+        }
+        return (
+            await Api(**api, credential=self.credential).update_params(**params).result
+        )
+
+    async def get_media_list(
+        self,
+        mobi_app: str = 'web',
+        type_: int = 1,
+        oid: int|None = None,
+        otype: int = 2,
+        ps: int = 20,
+        direction: bool = False,
+        desc: bool = True,
+        sort_field: int = MedialistOrder.PUBDATE,
+        tid: int = 0,
+        with_current: bool = False
+    ) -> dict:
+        """
+        以 medialist 形式获取用户投稿信息。
+
+        Args:
+            mobi_app        (str, optional)         : 未知
+            type_           (int)                   : 未知
+            oid             (int, optional)         : 未知
+            otype           (int, optional)         : 未知
+            ps              (int, optional)         : 每一页的番剧数. Defaults to 20. Max 100
+            direction       (bool, optional)        : 未知
+            desc            (bool, optional)        : 倒序排序. Defaults to True.
+            sort_field      (int, optional)         : 用于排序的栏  1 发布时间， 2 播放量
+            tid             (int, optional)         : 分区 ID. Defaults to 0（全部）.
+            with_current    (bool, optional)        : 未知
+
+        Returns:
+            dict: 调用接口返回的内容。
+        """
+        api = API["info"]["media_list"]
+        params = {
+            "mobi_app": mobi_app,
+            "type": type_,
+            "biz_id": self.__uid,
+            "oid": oid,
+            "otype": otype,
+            "ps": ps,
+            "direction": direction,
+            "desc": desc,
+            "sort_field": sort_field,
+            "tid": tid,
+            "with_current": with_current
         }
         return (
             await Api(**api, credential=self.credential).update_params(**params).result

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -37,13 +37,13 @@ class MedialistOrder(Enum):
     """
     medialist排序顺序。
 
-    + PUBDATE : 上传日期倒序。
-    + COLLECT : 收藏量倒序。
-    + VIEW    : 播放量倒序。
+    + PUBDATE : 上传日期。
+    + COLLECT : 收藏量。
+    + PLAY    : 播放量。
     """
 
     PUBDATE = 1
-    VIEW = 2
+    PLAY = 2
     COLLECT = 3
 
 

--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -451,7 +451,7 @@ class User:
         ps: int = 20,
         direction: bool = False,
         desc: bool = True,
-        sort_field: int = MedialistOrder.PUBDATE,
+        sort_field: MedialistOrder = MedialistOrder.PUBDATE,
         tid: int = 0,
         with_current: bool = False
     ) -> dict:
@@ -483,7 +483,7 @@ class User:
             "ps": ps,
             "direction": direction,
             "desc": desc,
-            "sort_field": sort_field,
+            "sort_field": sort_field.value,
             "tid": tid,
             "with_current": with_current
         }

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -18,6 +18,18 @@ from bilibili_api import user
 
 ---
 
+## class VideoOrder
+
+**Extends:** enum.Enum
+
+视频排序顺序。
+
++ PUBDATE : 上传日期倒序。
++ COLLECT: 收藏量倒序。
++ VIEW  : 播放量倒序。
+
+---
+
 ## class ChannelOrder
 
 **Extends:** enum.Enum
@@ -259,6 +271,25 @@ from bilibili_api import user
 | ps      | (int, optional)      | 每一页的视频数. Defaults to 30.             |
 | keyword | str, optional        | 搜索关键词. Defaults to "".               |
 | order   | VideoOrder, optional | 排序方式. Defaults to VideoOrder.PUBDATE |
+
+获取用户投稿视频信息。
+
+**Returns:** 调用接口返回的内容。
+
+#### async def get_media_list()
+
+| name         | type           | description                              |
+|--------------|----------------|------------------------------------------|
+| mobi_app     | str, optional  | 未知                                       |
+| type         | int            | int: 未知， 必填                              |
+| oid          | int, optional  | 未知                                       |
+| otype        | int, optional  | 未知                                       |
+| ps           | int, optional  | 每一页的视频数. Defaults to 20.                 |
+| direction    | bool, optional | 未知                                       |
+| desc         | bool, optional | 是否倒序                                     |
+| sort_field   | int, optional  | 排序方式. Defaults to MedialistOrder.PUBDATE |
+| tid          | int, optional  | 分区 ID，0 表示全部                             |
+| with_current | bool, optional | 未知                                       |
 
 获取用户投稿视频信息。
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -25,8 +25,8 @@ from bilibili_api import user
 medialist排序顺序。
 
 + PUBDATE : 上传日期。
-+ COLLECT: 收藏量。
 + PLAY  : 播放量。
++ COLLECT: 收藏量。
 
 ---
 
@@ -280,16 +280,13 @@ medialist排序顺序。
 
 | name         | type           | description                              |
 |--------------|----------------|------------------------------------------|
-| mobi_app     | str, optional  | 未知                                       |
-| type         | int            | int: 未知， 必填                              |
-| oid          | int, optional  | 未知                                       |
-| otype        | int, optional  | 未知                                       |
+| oid          | int, optional  | 起始视频 aid， 默认为列表开头                        |
 | ps           | int, optional  | 每一页的视频数. Defaults to 20.                 |
-| direction    | bool, optional | 未知                                       |
+| direction    | bool, optional | 相对于给定oid的查询方向，true：向列表末尾方向，false：向列表开头方向 |
 | desc         | bool, optional | 是否倒序                                     |
 | sort_field   | int, optional  | 排序方式. Defaults to MedialistOrder.PUBDATE |
 | tid          | int, optional  | 分区 ID，0 表示全部                             |
-| with_current | bool, optional | 未知                                       |
+| with_current | bool, optional | 返回的列表中是否包含给定oid自身                        |
 
 获取用户投稿视频信息。
 

--- a/docs/modules/user.md
+++ b/docs/modules/user.md
@@ -18,15 +18,15 @@ from bilibili_api import user
 
 ---
 
-## class VideoOrder
+## class MedialistOrder
 
 **Extends:** enum.Enum
 
-视频排序顺序。
+medialist排序顺序。
 
-+ PUBDATE : 上传日期倒序。
-+ COLLECT: 收藏量倒序。
-+ VIEW  : 播放量倒序。
++ PUBDATE : 上传日期。
++ COLLECT: 收藏量。
++ PLAY  : 播放量。
 
 ---
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -45,6 +45,10 @@ async def test_e_User_get_videos():
     return await u.get_videos()
 
 
+async def test_e_User_get_media_list():
+    return await u.get_media_list()
+
+
 async def test_f_User_get_audios():
     return await u.get_audios()
 


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# 以medialist形式获取用户的所有视频
接口：https://api.bilibili.com/x/v2/medialist/resource/list
新增 MedialistOrder， get_media_list()
同时更新API, docs, test
部分参数（mobi_app， type，oid，otype，direction，with_current）的作用仍未知
经测试[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1X6HIAI3W22AjWHI1v_EMrfFTzjAGTwUg?usp=sharing)可以获得期望的结果
注意到：
分P视频被视为一个视频
合集被展开为多个视频


<!-- 请向 dev 分支发起 pull request-->
