### PR TITLE
fix: 修复安装时文件缺失的错误

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,26 @@ version = { attr = "bilibili_api.BILIBILI_API_VERSION" }
 readme = { file = ["README.md"], content-type = "text/markdown" }
 dependencies = { file = ["requirements.txt"] }
 
-[tool.setuptools.packages.find]
-include = ["bilibili_api"]
-exclude = []
+[tool.setuptools]
+packages = [
+    "bilibili_api",
+    "bilibili_api.utils",
+    "bilibili_api.exceptions",
+    "bilibili_api.errors",
+    "bilibili_api.tools",
+    "bilibili_api.tools.opendocs",
+    "bilibili_api.tools.ivitools",
+    "bilibili_api.tools.parser",
+    "bilibili_api._pyinstaller",
+]
+
+[tool.setuptools.package-data]
+"*" = [
+    "data/**/*.*",
+    "py.typed",
+    "requirements.txt",
+    "data/*.*",
+    "data/article/*.*",
+    "data/geetest/*.*",
+    "data/corerespond/*.*",
+]


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# 修复安装 bilibili-api 时文件安装不全的问题
- 1. {新增}
- 2. {修复}
之前的写法实测会导致安装依赖时仅安装 bilibili_api 文件夹内的文件，所有的子目录（如 utils、errors）均被忽略。
该 PR 摘抄了原有 setup.py 文件中关于 package 和 package-data 的描述，测试正常工作。
- 3. {其他}

<!-- 请向 dev 分支发起 pull request-->
