### PR TITLE
feat: add bnj to be able to resolve url without bvid in `parse_link` by __INITIAL_STATE__

### DIFF
--- a/bilibili_api/utils/parse_link.py
+++ b/bilibili_api/utils/parse_link.py
@@ -33,6 +33,8 @@ from ..interactive_video import InteractiveVideo
 from ..favorite_list import FavoriteList, FavoriteListType
 from ..user import User, ChannelSeries, ChannelSeriesType, get_self_info
 
+from .initial_state import get_initial_state_sync
+
 
 class ResourceType(Enum):
     """
@@ -628,6 +630,15 @@ def parse_bnj(url: URL, credential: Credential) -> Union[Video, int]:
     bvid = url.query.get("bvid")
     if bvid is not None:
         return Video(bvid, credential=credential)
+
+    # 如果是https://www.bilibili.com/festival/2023bnj无bvid, 使用 __INITIAL_STATE__ 来获取信息
+    pattern = re.compile(pattern=r"^https://www\.bilibili\.com/festival/20[2-9][0-9]bnj")
+    match = re.match(pattern=pattern, string=str(url))
+
+    if match:
+        content, content_type = get_initial_state_sync(url=str(url), credential=credential)
+        return Video(content['videoSections'][0]['episodes'][0]['bvid'], credential=credential)
+
     return -1
 
 

--- a/bilibili_api/utils/parse_link.py
+++ b/bilibili_api/utils/parse_link.py
@@ -172,10 +172,6 @@ async def parse_link(
         if topic != -1:
             topic.credential = credential  # type: ignore
             return (topic, ResourceType.TOPIC)  # type: ignore
-        bnj_video = parse_bnj(url, credential)  # type: ignore
-        if bnj_video != -1:
-            bnj_video.credential = credential  # type: ignore
-            return (bnj_video, ResourceType.VIDEO)  # type: ignore
         festival_video = await parse_festival(url, credential)  # type: ignore
         if festival_video != -1:
             festival_video.credential = credential  # type: ignore
@@ -629,15 +625,12 @@ def parse_manga(url: URL, credential: Credential) -> Union[Manga, int]:
     return -1
 
 
-def parse_bnj(url: URL, credential: Credential) -> Union[Video, int]:
-    # https://www.bilibili.com/festival/2023bnj?bvid=BV1ZY4y1f79x&spm_id_from=333.999.0.0
-    bvid = url.query.get("bvid")
-    if bvid is not None:
-        return Video(bvid, credential=credential)
-    return -1
-
 async def parse_festival(url: URL, credential: Credential) -> Union[Video, int]:
-    if url.host == "www.bilibili.com" and url.parts[1] == "festival":
+    bvid = url.query.get("bvid")
+    if bvid is not None:  # get bvid if provided
+        return Video(bvid, credential=credential)
+
+    if url.host == "www.bilibili.com" and url.parts[1] == "festival":  # use __initial_state__ to fetch
         content, content_type = await get_initial_state(url=str(url), credential=credential)
         return Video(content['videoSections'][0]['episodes'][0]['bvid'], credential=credential)  # 返回当前第一个视频
     return -1


### PR DESCRIPTION
为`parse_link`添加了处理拜年纪url中没有bvid的情况，通过Nemo说的`__INITIAL_STATE__`来获取bvid
- 目前返回所有返回值里第一个视频（也就是正片第一个）

如果认为返回整个`dict`或者返回一个全部`bvid`的列表，我也可以改一下。（词典会稍稍麻烦些因为没法塞到Video类里，然后列表的话就看不到分类（比如说正片，单品，等等））
