### PR TITLE
fix TypeError: 'NoneType' + 'int' in history danmuku

### DIFF
--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -858,6 +858,7 @@ class Video:
             api = API["danmaku"]["get_history_danmaku"]
             params["date"] = date.strftime("%Y-%m-%d")
             params["type"] = 1
+            from_seg = to_seg = 0
         else:
             api = API["danmaku"]["get_danmaku"]
             if from_seg == None:


### PR DESCRIPTION
当获取历史弹幕时`danmakus = await v.get_danmakus(0, date=danmaku_date)` 
，需要初始化from_seg，to_seg。
否则下面语句 `for seg in range(from_seg, to_seg+1)`
会产生TypeError。
