### PR TITLE
fix session

### DIFF
--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -2,17 +2,17 @@
 
 ```python
 from bilibili_api import Credential, sync
-from bilibili_api.session import Session, Event
-from bilibili_api.utils.Picture import Picture
+from bilibili_api.session import Session, Event, EventType
+from bilibili_api.utils.picture import Picture
 
 session = Session(Credential(...))
 
-@session.on(Event.PICTURE)
+@session.on(EventType.PICTURE)
 async def pic(event: Event):
     img: Picture = event.content
     img.download("./")
 
-@session.on(Event.TEXT)
+@session.on(EventType.TEXT)
 async def reply(event: Event):
     if event.content == "/close":
         session.close()

--- a/docs/modules/session.md
+++ b/docs/modules/session.md
@@ -222,17 +222,17 @@ from bilibili_api import session
 
 #### async def run()
 
-| name        | type           | description                  |
-| ----------- | -------------- | ---------------------------- |
-| except_self | bool, optional | 是否排除自己发出的消息，默认是 |
+| name        | type           | description                     |
+| ----------- | -------------- | ------------------------------- |
+| exclude_self | bool, optional | 是否排除自己发出的消息，默认排除 |
 
 不阻塞开始轮询
 
 #### async def start()
 
-| name        | type           | description                  |
-| ----------- | -------------- | ---------------------------- |
-| except_self | bool, optional | 是否排除自己发出的消息，默认是 |
+| name        | type           | description                     |
+| ----------- | -------------- | ------------------------------- |
+| exclude_self | bool, optional | 是否排除自己发出的消息，默认排除 |
 
 阻塞开始轮询
 


### PR DESCRIPTION
### 修复 `Session` 不能正确绑定的问题
- 重载装饰器
- 重命名启动函数参数 `except_self` 为 `exclude_self`
- 一些注释修改
- 现在使用 `logging.error` 打印错误提示
