### PR TITLE
fix: bvid2aid

### DIFF
--- a/bilibili_api/utils/aid_bvid_transformer.py
+++ b/bilibili_api/utils/aid_bvid_transformer.py
@@ -6,57 +6,35 @@ av 号和 bv 号互转，代码来源：https://www.zhihu.com/question/381784377
 此部分代码以 WTFPL 开源。
 """
 
+XOR_CODE = 23442827791579
+MASK_CODE = 2251799813685247
+MAX_AID = 1 << 51
+
+data = [b'F', b'c', b'w', b'A', b'P', b'N', b'K', b'T', b'M', b'u', b'g', b'3', b'G', b'V', b'5', b'L', b'j', b'7', b'E', b'J', b'n', b'H', b'p', b'W', b's', b'x', b'4', b't', b'b', b'8', b'h', b'a', b'Y', b'e', b'v', b'i', b'q', b'B', b'z', b'6', b'r', b'k', b'C', b'y', b'1', b'2', b'm', b'U', b'S', b'D', b'Q', b'X', b'9', b'R', b'd', b'o', b'Z', b'f']
+
+BASE = 58
+BV_LEN = 12
+PREFIX = "BV1"
 
 def bvid2aid(bvid: str) -> int:
-    """
-    BV 号转 AV 号。
-
-    Args:
-        bvid (str):  BV 号。
-
-    Returns:
-        int: AV 号。
-    """
-    table = "fZodR9XQDSUm21yCkr6zBqiveYah8bt4xsWpHnJE7jL5VG3guMTKNPAwcF"
-    tr = {}
-    for i in range(58):
-        tr[table[i]] = i
-    s = [11, 10, 3, 8, 4, 6]
-    xor = 177451812
-    add = 8728348608
-
-    def dec(x):
-        r = 0
-        for i in range(6):
-            r += tr[x[s[i]]] * 58**i
-        return (r - add) ^ xor
-
-    return dec(bvid)
-
+    bvid = list(bvid)
+    bvid[3], bvid[9] = bvid[9], bvid[3]
+    bvid[4], bvid[7] = bvid[7], bvid[4]
+    bvid = bvid[3:]
+    tmp = 0
+    for i in bvid:
+        idx = data.index(i.encode())
+        tmp = tmp * BASE + idx
+    return (tmp & MASK_CODE) ^ XOR_CODE
 
 def aid2bvid(aid: int) -> str:
-    """
-    AV 号转 BV 号。
-
-    Args:
-        aid (int):  AV 号。
-
-    Returns:
-        str: BV 号。
-    """
-    table = "fZodR9XQDSUm21yCkr6zBqiveYah8bt4xsWpHnJE7jL5VG3guMTKNPAwcF"
-    tr = {}
-    for i in range(58):
-        tr[table[i]] = i
-    s = [11, 10, 3, 8, 4, 6]
-    xor = 177451812
-    add = 8728348608
-
-    def enc(x):
-        x = (x ^ xor) + add
-        r = list("BV1  4 1 7  ")
-        for i in range(6):
-            r[s[i]] = table[x // 58**i % 58]
-        return "".join(r)
-
-    return enc(aid)
+    bytes = [b'B', b'V', b'1', b'0', b'0', b'0', b'0', b'0', b'0', b'0', b'0', b'0']
+    bv_idx = BV_LEN - 1
+    tmp = (MAX_AID | aid) ^ XOR_CODE
+    while int(tmp) != 0:
+        bytes[bv_idx] = data[int(tmp % BASE)]
+        tmp /= BASE
+        bv_idx -= 1
+    bytes[3], bytes[9] = bytes[9], bytes[3]
+    bytes[4], bytes[7] = bytes[7], bytes[4]
+    return "".join([i.decode() for i in bytes])

--- a/bilibili_api/utils/aid_bvid_transformer.py
+++ b/bilibili_api/utils/aid_bvid_transformer.py
@@ -17,6 +17,13 @@ BV_LEN = 12
 PREFIX = "BV1"
 
 def bvid2aid(bvid: str) -> int:
+    """
+    BV 号转 AV 号。
+    Args:
+        bvid (str):  BV 号。
+    Returns:
+        int: AV 号。
+    """
     bvid = list(bvid)
     bvid[3], bvid[9] = bvid[9], bvid[3]
     bvid[4], bvid[7] = bvid[7], bvid[4]
@@ -28,6 +35,13 @@ def bvid2aid(bvid: str) -> int:
     return (tmp & MASK_CODE) ^ XOR_CODE
 
 def aid2bvid(aid: int) -> str:
+    """
+    AV 号转 BV 号。
+    Args:
+        aid (int):  AV 号。
+    Returns:
+        str: BV 号。
+    """
     bytes = [b'B', b'V', b'1', b'0', b'0', b'0', b'0', b'0', b'0', b'0', b'0', b'0']
     bv_idx = BV_LEN - 1
     tmp = (MAX_AID | aid) ^ XOR_CODE


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

BV 号 av 号转换算法不适用于 av 号大于 29460791296 的情况

最近获取不到下载链接了，发现bvid都转换不了

https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/misc/bvid_desc.md

https://github.com/SocialSisterYi/bilibili-API-collect/issues/740

# {请说明更改}
- 1. {新增}
- 2. {修复}
- 3. {其他}

<!-- 请向 dev 分支发起 pull request-->
