### PR TITLE
fix: Only show the name under license field (since classifier include…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
     { name = "Nemo2011" },
 ]
 dynamic = ["version", "readme", "dependencies"]
-license = { file = "LICENSE", content-type = "text/plain" }
+license = { text = "GPL-3.0-or-later" }
 description = "The fork of module bilibili-api. 哔哩哔哩的各种 API 调用便捷整合（视频、动态、直播等），另外附加一些常用的功能。"
 requires-python = ">=3.7"
 keywords = ["bilibili", "api", "spider"]


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# pip show会显示整个license文件信息
- issue: #688 
- 因为GPLv3是广泛认可的license，所以根据pyproject.toml的guide可以直接写一个名字，然后在classifier里包含就可以

<!-- 请向 dev 分支发起 pull request-->
