### PR TITLE
fix: get_danmaku_xml 发起的请求现需要 `User-Agent` 头部

### DIFF
--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -1203,6 +1203,7 @@ class Video:
         url = f"https://comment.bilibili.com/{cid}.xml"
         sess = get_session()
         config: dict[Any, Any] = {"url": url}
+        config["headers"] = {"User-Agent": "Mozilla/5.0"}
         # 代理
         if settings.proxy:
             config["proxies"] = {"all://", settings.proxy}


### PR DESCRIPTION
Bilibili 的弹幕接口请求 `comment.bilibili.com` 现需要 `User-Agent` 头部，否则会引发风控。

测试：

- 无 `User-Agent` 头部：
```
$ python -c 'import requests; print(requests.get("https://comment.bilibili.com/279786.xml"))'
<Response [412]>
```

- 有 `User-Agent` 头部：
```
$ python -c 'import requests; print(requests.get("https://comment.bilibili.com/279786.xml", headers={"User-Agent":"Mozilla/5.0"}))'
<Response [200]>
```

此 Pull Request 为 `get_danmaku_xml` 中的请求添加了 `User-Agent: Mozilla/5.0` 的头部，其功能恢复正常。
