### PR TITLE
修复用户部分接口风控校验失败

### DIFF
--- a/bilibili_api/utils/user_render_data.py
+++ b/bilibili_api/utils/user_render_data.py
@@ -1,0 +1,43 @@
+import json
+from re import Match, Pattern, compile
+from typing import Any
+from urllib.parse import unquote
+
+from httpx import AsyncClient, Response, HTTPStatusError, codes
+
+from bilibili_api.utils.network import get_session, HEADERS, NetworkException, ApiException
+
+
+RENDER_DATA_PATTERN: Pattern[str] = compile(
+    r"<script id=\"__RENDER_DATA__\" type=\"application/json\">(.*?)</script>")
+
+
+async def get_user_dynamic_render_data(uid: int) -> dict[str, Any]:
+    """
+    获取用户动态页面加载静态渲染数据 获取部分接口需要的w_webid关键参数
+
+    :param uid: 用户ID 示例参数: 208259
+    :return: 用户动态页面服务端渲染提取数据结构
+    """
+
+    dynamic_url: str = "https://space.bilibili.com/{}/dynamic".format(uid)
+
+    session: AsyncClient = get_session()
+    response: Response = await session.get(url=dynamic_url, headers=HEADERS)
+    try:
+        response.raise_for_status()
+    except HTTPStatusError as e:
+        raise NetworkException(response.status_code, codes.get_reason_phrase(response.status_code))
+
+    response_content_text: str = response.text
+    match: Match = RENDER_DATA_PATTERN.search(response_content_text)
+    if match is None:
+        raise ApiException("未匹配到用户动态页渲染数据")
+
+    script_render_data: str = match.group(1)
+    try:
+        extract_json = json.loads(unquote(script_render_data))
+        return extract_json
+    except json.JSONDecodeError as e:
+        raise ApiException("序列化用户动态页渲染数据异常" + str(e))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tqdm~=4.66.5
 yarl~=1.11.1
 pycryptodomex~=3.20.0
 qrcode_terminal~=0.8
+PyJWT~=2.9.0


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->
获取用户个人页面静态渲染数据工具 用于获取 user 部分接口风控所需的  "w_webid" 参数内容 由于跟用户相关 所以在User类型新增属性 __access_id  防止同一 User 对象重复获取  在对象自身懒加载存储 采用解析 JWT 的方式判断是否有效 

# {请说明更改}
- 1. {新增}  在utils下新增解析用户个人页静态渲染数据工具 
- 2. {修复} User.get_user_info, User.get_live_info 接口风控校验失败
- 3. {其他} 引入新的依赖 PyJWT 用于解析 access_id 对应的 JWT 是否有效

<!-- 请向 dev 分支发起 pull request-->
