### PR TITLE
直播禁言用户添加hour参数

### DIFF
--- a/bilibili_api/data/api/live.json
+++ b/bilibili_api/data/api/live.json
@@ -321,6 +321,7 @@
         "room_id": "int: 真实房间号",
         "tuid": "int: 封禁用户 UID",
         "mobile_app": "str: 设备类型",
+        "hour": "int: 禁言小时数， -1永久，0本场",
         "visit_id": "str: 空"
       },
       "comment": "封禁用户"

--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -470,12 +470,13 @@ class LiveRoom:
             await Api(**api, credential=self.credential).update_params(**params).result
         )
 
-    async def ban_user(self, uid: int) -> dict:
+    async def ban_user(self, uid: int, hour: int) -> dict:
         """
         封禁用户
 
         Args:
             uid (int): 用户 UID
+            hour (int): 禁言时长，-1为永久，0为直到本场结束
 
         Returns:
             dict: 调用 API 返回的结果
@@ -487,6 +488,7 @@ class LiveRoom:
             "room_id": self.room_display_id,
             "tuid": uid,
             "mobile_app": "web",
+            "hour": hour,
             "visit_id": "",
         }
         return await Api(**api, credential=self.credential).update_data(**data).result

--- a/docs/modules/live.md
+++ b/docs/modules/live.md
@@ -148,6 +148,7 @@ Events：
 | name | type | description |
 | - | - | - |
 | uid | int | 用户 UID |
+| hour | int | 禁言时长，-1永久，0本场 |
 
 **Returns:** dict: 调用 API 返回的结果
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -54,7 +54,7 @@ async def test_j_get_danmu_info():
 
 async def test_k_ban_user():
     try:
-        return await l.ban_user(1)
+        return await l.ban_user(1, 1)
     except ResponseCodeException as e:
         if e.code == 1200000:
             return e.raw


### PR DESCRIPTION
直播禁言用户添加hour参数

近期禁言用户api新增hour参数，缺少此参数会导致禁言失败又不报错。

给ban_user新增hour参数，并相应修改了api，测试，与文档
