### PR TITLE
search.search_by_type 增加功能：可以按照时间段查询 & 新增 to_timestamps 函数

### DIFF
--- a/bilibili_api/search.py
+++ b/bilibili_api/search.py
@@ -6,7 +6,7 @@ bilibili_api.search
 import json
 from enum import Enum
 from typing import List, Union, Callable
-
+from .utils.utils import to_timestamps
 from .utils.utils import get_api
 from .video_zone import VideoZoneTypes
 from .utils.network import Api, get_session
@@ -193,6 +193,10 @@ async def search_by_type(
         category_id      (CategoryTypeArticle | CategoryTypePhoto | int | None, optional)        : 专栏/相簿分区筛选，指定分类，只在相册和专栏类型下生效
 
         time_range       (int, optional)                                                         : 指定时间，自动转换到指定区间，只在视频类型下生效 有四种：10分钟以下，10-30分钟，30-60分钟，60分钟以上
+        
+        time_start       (str, optional)                                                         : 指定开始时间，与结束时间搭配使用，格式为："YYYY-MM-DD"
+
+        time_end         (str, optional)                                                         : 指定结束时间，与开始时间搭配使用，格式为："YYYY-MM-DD"
 
         video_zone_type  (int | ZoneTypes | None, optional)                                      : 话题类型，指定 tid (可使用 channel 模块查询)
 
@@ -254,6 +258,11 @@ async def search_by_type(
         params["order_sort"] = order_sort
     if debug_param_func:
         debug_param_func(params)
+    # time setting
+    if time_start and time_end:
+        time_stamp = to_timestamps(time_start,time_end)
+        params["pubtime_begin_s"] = time_stamp[0]
+        params["pubtime_end_s"] = time_stamp[1]
     api = API["search"]["web_search_by_type"]
     return await Api(**api, wbi=True).update_params(**params).result
 

--- a/bilibili_api/utils/utils.py
+++ b/bilibili_api/utils/utils.py
@@ -9,7 +9,7 @@ import os
 import random
 from typing import List, TypeVar
 from ..exceptions import StatementException
-
+from datetime import datetime
 
 def get_api(field: str, *args) -> dict:
     """
@@ -210,3 +210,25 @@ def get_deviceid(separator: str = "-", is_lowercase: bool = False) -> str:
 def raise_for_statement(statement: bool, msg: str="未满足条件") -> None:
     if not statement:
         raise StatementException(msg=msg)
+
+def to_timestamps(time_start, time_end):
+    """
+    将两个日期字符串转换为整数时间戳 (int) 元组，并验证时间顺序。
+    
+    Returns:
+        tuple: (int,int)
+    """
+    try:
+        # 将输入字符串解析为 datetime 对象
+        start_dt = datetime.strptime(time_start, "%Y-%m-%d")
+        end_dt = datetime.strptime(time_end, "%Y-%m-%d")
+        
+        # 验证起始时间是否早于结束时间
+        if start_dt >= end_dt:
+            raise ValueError("起始时间必须早于结束时间。")
+        
+        # 转换为时间戳并返回
+        return int(start_dt.timestamp()), int(end_dt.timestamp())
+    except ValueError as e:
+        # 捕获日期格式错误或自定义错误消息
+        raise ValueError(f"输入错误: {e}. 请确保使用 'YYYY-MM-DD' 格式，并且起始时间早于结束时间。")

--- a/docs/modules/search.md
+++ b/docs/modules/search.md
@@ -213,6 +213,8 @@ Ps: Api 中 的 order_sort 字段决定顺序还是倒序
 | order_sort | Union[int, None] | 用户粉丝数及等级排序顺序 默认为0 由高到低：0 由低到高：1 |
 | category_id | Union[CategoryTypeArticle, None] | 专栏/相簿分区筛选，指定分类，只在相册和专栏类型下生效 |
 | time_range | Union[int, None] | 指定时间，自动转换到指定区间，只在视频类型下生效 有四种：10分钟以下，10-30分钟，30-60分钟，60分钟以上 |
+| time_start | Union[str, None] | 指定搜索开始日期，与结束日期搭配使用，格式为："YYYY-MM-DD" |
+| time_end | Union[str, None] | 指定搜索结束日期，与开始日期搭配使用，格式为："YYYY-MM-DD" |
 | video_zone_type | Union[int, None] | 话题类型，指定 tid (可使用 channel 模块查询) |
 | order_type | Union[OrderUser, None] | 排序分类类型 |
 | keyword | str | 搜索关键词 |


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# search.search_by_type 增加功能：可以按照时间段查询 & 新增 to_timestamps 函数
本次 Pull Request 主要完成了以下更改：

1. **新增功能：**
   - **`search.search_by_type` 新增参数：**
     - `time_start` 和 `time_end` 用于支持按照时间段进行查询。
     - 时间段参数的使用方式：
       - `time_start`：查询的起始时间，格式为 `YYYY-MM-DD`。
       - `time_end`：查询的结束时间，格式为 `YYYY-MM-DD`。
     - 功能特点：支持精准的时间段过滤。
   - **新增工具函数 `to_timestamps`：**
     - 文件位置：`utils.utils`
     - 功能描述：将日期字符串（如 `YYYY-MM-DD`）转换为 Unix 时间戳。
     - 参数说明：
       - `date_str` (str): 日期字符串，格式为 `YYYY-MM-DD`。
     - 返回值：对应的 Unix 时间戳（整数）。
     - 用途：辅助时间段查询功能，确保输入的时间参数能够被正确解析。


<!-- 请向 dev 分支发起 pull request-->
