### PR TITLE
fix: 查看用户合集中的视频（新版）API变更

### DIFF
--- a/bilibili_api/data/api/user.json
+++ b/bilibili_api/data/api/user.json
@@ -384,7 +384,7 @@
       "comment": "查看列表内视频（旧版）"
     },
     "channel_video_season": {
-      "url": "https://api.bilibili.com/x/polymer/space/seasons_archives_list",
+      "url": "https://api.bilibili.com/x/polymer/web-space/seasons_archives_list",
       "method": "GET",
       "verify": false,
       "params": {


### PR DESCRIPTION
<!-- 欢迎来到 pull requests -->

<!-- 说明一下你的 pull -->

# fix: 查看用户合集中的视频（新版）API变更
当前视频合集API地址解析后为：
https://api.bilibili.com/x/polymer/space/seasons_archives_list?mid=391930545&season_id=598034&sort_reverse=false&page_num=1&page_size=100&wts=1737513661&web_location=1550101&w_rid=42092757abce9f53520da3ca3a308192

返回404

新API地址为：
https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?mid=391930545&season_id=598034&sort_reverse=false&page_num=1&page_size=100&wts=1737513661&web_location=1550101&w_rid=42092757abce9f53520da3ca3a308192
<!-- 请向 dev 分支发起 pull request-->
