### PR TITLE
fix: 为live.py中的裸except添加log

### DIFF
--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -950,6 +950,7 @@ class LiveDanmaku(AsyncEvent):
         credential: Union[Credential, None] = None,
         max_retry: int = 5,
         retry_after: float = 1,
+        max_retry_for_credential: int = 5,
     ):
         """
         Args:
@@ -967,6 +968,7 @@ class LiveDanmaku(AsyncEvent):
         self.room_display_id: int = room_display_id
         self.max_retry: int = max_retry
         self.retry_after: float = retry_after
+        self.max_retry_for_credential: int = max_retry_for_credential
         self.__room_real_id = None
         self.__status = 0
         self.__ws = None
@@ -1211,12 +1213,28 @@ class LiveDanmaku(AsyncEvent):
     async def __send_verify_data(self, token: str) -> None:
         # 没传入 dedeuserid 可以试图 live.get_self_info
         if not self.credential.has_dedeuserid():
-            try:
-                info = await get_self_info(self.credential)
-                self.credential.dedeuserid = str(info["uid"])
-            except Exception as e:
-                self.logger.warning(f"获取用户信息失败，使用匿名身份: {e}")
+            if not self.credential.has_sessdata():
+                self.logger.warning("未提供登录凭据，使用匿名身份连接")
                 self.credential.dedeuserid = 0
+            else:
+                for attempt in range(self.max_retry_for_credential):
+                    if self.credential.has_dedeuserid():
+                        break
+                    try:
+                        info = await get_self_info(self.credential)
+                        self.credential.dedeuserid = str(info.get("uid", 0))
+                        if self.credential.has_dedeuserid():
+                            break
+                    except Exception as e:
+                        self.logger.warning(
+                            f"获取用户信息失败，重试中... ({attempt + 1}/{self.max_retry_for_credential})\n{e}"
+                        )
+                        await asyncio.sleep(self.retry_after)
+                if not self.credential.has_dedeuserid():
+                    self.credential.dedeuserid = 0
+                    self.logger.warning("获取用户信息失败，使用匿名身份连接")
+
+ 
         verifyData = {
             "uid": int(self.credential.dedeuserid),
             "roomid": self.__room_real_id,


### PR DESCRIPTION
目前，`live.py` 的第1217行 `__send_verify_data()` 方法中，会试图获取 dedeuserid 用于后续操作；如果获取失败，会将其静默地置0，即以游客身份进行后续操作。这个静默的 fallback 可能造成用户困惑；因此我们在这里添加了一个 `logger.warning`，提示用户这里进行了 fallback 。
