### PR TITLE
fix: 修复pylint在git hooks中的执行问题

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,4 +1,4 @@
 import os
 
 # Check the code.
-exit(os.system("pylint -E ./bilibili_api"))
+exit(os.system("python -m pylint -E ./bilibili_api"))


### PR DESCRIPTION
在 git 前置脚本中，直接调用 `pylint` 命令可能在某些环境下失败，导致代码检查无法正常运行。

这里我们将 `pylint` 调用方式从：

```python
exit(os.system("pylint -E ./bilibili_api"))
```

改为
```python
exit(os.system("python -m pylint -E ./bilibili_api"))
```

