### PR TITLE
fix: Remove default voice_balance parameter to prevent it from being enabled by default

### DIFF
--- a/bilibili_api/bangumi.py
+++ b/bilibili_api/bangumi.py
@@ -1560,7 +1560,6 @@ class Episode(Video):
                 "need_fragment": "false",
                 "isGaiaAvoided": "true",
                 "web_location": 1315873,
-                "voice_balance": 1,
             }
             self.__playurl = (
                 await Api(**api, credential=self.credential)

--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -502,7 +502,6 @@ class Video:
             "need_fragment": "false",
             "isGaiaAvoided": "true",
             "web_location": 1315873,
-            "voice_balance": 1,
         }
         return (
             await Api(**api, credential=self.credential, wbi=True)


### PR DESCRIPTION
The voice_balance parameter was hardcoded to 1 in both Video and Episode classes. This change removes the default setting.