### PR TITLE
fix: 获取用户 access_id 时带上 Credential

### DIFF
--- a/bilibili_api/user.py
+++ b/bilibili_api/user.py
@@ -1060,7 +1060,7 @@ class User:
         Returns:
             str: access_id
         """
-        return await get_user_dynamic_render_data(self.__uid)
+        return await get_user_dynamic_render_data(self.__uid, self.credential)
 
 
 async def get_self_info(credential: Credential) -> dict:

--- a/bilibili_api/utils/user_render_data.py
+++ b/bilibili_api/utils/user_render_data.py
@@ -5,7 +5,7 @@ from typing import Any
 from urllib.parse import unquote
 
 from ..exceptions import ApiException, NetworkException
-from .network import HEADERS, get_client
+from .network import Credential, HEADERS, get_client
 
 import jwt
 
@@ -17,7 +17,7 @@ access_ids = {}
 last_timestamp = {}
 
 
-async def get_user_dynamic_render_data(uid: int) -> dict[str, Any]:
+async def get_user_dynamic_render_data(uid: int, credential: Credential) -> dict[str, Any]:
     """
     获取用户动态页面加载静态渲染数据 获取部分接口需要的 w_webid 关键参数
 
@@ -30,7 +30,8 @@ async def get_user_dynamic_render_data(uid: int) -> dict[str, Any]:
     dynamic_url: str = "https://space.bilibili.com/{}/dynamic".format(uid)
 
     session = get_client()
-    response = await session.request(method="GET", url=dynamic_url, headers=HEADERS)
+    response = await session.request(method="GET", url=dynamic_url,
+                                     headers=HEADERS, cookies=credential.get_cookies())
     if response.code != 200:
         raise NetworkException(response.code, "")
 


### PR DESCRIPTION
在云服务器 IP 请求用户视频时，遇到 412 错误
```python
----> 1 await u.get_videos()

File ~/.local/lib/python3.13/site-packages/bilibili_api/user.py:463, in User.get_videos(self, tid, pn, ps, keyword, order)
    436 """
    437 获取用户投稿视频信息。
    438 
   (...)    451     dict: 调用接口返回的内容。
    452 """
    453 api = API["info"]["video"]
    454 params = {
    455     "mid": self.__uid,
    456     "ps": ps,
    457     "tid": tid,
    458     "pn": pn,
    459     "keyword": keyword,
    460     "order": order.value,
    461     "order_avoided": True,
    462     "platform": "web",
--> 463     "w_webid": await self.get_access_id(),
    464 }
    465 return (
    466     await Api(**api, credential=self.credential).update_params(**params).result
    467 )

File ~/.local/lib/python3.13/site-packages/bilibili_api/user.py:1063, in User.get_access_id(self)
   1056 async def get_access_id(self) -> str:
   1057     """
   1058     获取用户 access_id (w_webid) 如未过期直接从本地获取 防止重复请求
   1059 
   1060     Returns:
   1061         str: access_id
   1062     """
-> 1063     return await get_user_dynamic_render_data(self.__uid)

File ~/.local/lib/python3.13/site-packages/bilibili_api/utils/user_render_data.py:35, in get_user_dynamic_render_data(uid)
     33 response = await session.request(method="GET", url=dynamic_url, headers=HEADERS)
     34 if response.code != 200:
---> 35     raise NetworkException(response.code, "")
     37 response_content_text: str = response.utf8_text()
     38 match: Match = RENDER_DATA_PATTERN.search(response_content_text)

NetworkException: 网络错误，状态码：412 - 。
```

用相同 IP 直接在浏览器访问用户页（调用完全相同的 API）可以成功，经 traceback 可见 412 发生在 get_user_dynamic_render_data 函数中，而并非在 `API["info"]["video"]` 中

查阅 `utils/user_render_data.py` 可见，请求 user_dynamic_render_data 时没有携带任何用户 Cookie

PR 增加传递了 Credential 参数，并直接使用该类的 `get_cookies()` 方法导出 Cookies 字典发起网络请求，经服务器测试可成功解决 412 问题