### PR TITLE
增加了字幕格式的输出，可以完成类似于json的转换方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 # Danmakus
 *.ass
 *.srt
+*.lrc
+*.json
 # Interactive Videos
 *.ivi
 # Videos
@@ -24,8 +26,9 @@ venv/
 virtualenv/
 # IDE
 .idea/
-.vscode/settings.json
-.vscode/launch.json
+.vscode
 # Doc Generater
 .doc_cache/
 .mypy_cache/
+# sh
+env.sh

--- a/bilibili_api/utils/srt2ass.py
+++ b/bilibili_api/utils/srt2ass.py
@@ -26,7 +26,8 @@ def fileopen(input_file):
             continue
     return [tmp, enc]
 
-def srt2ass_cover_by_str(srt_string: str):
+# 修复命名问题
+def srt2ass_from_string(srt_string: str):
     utf8bom = ""
 
     if "\ufeff" in srt_string:
@@ -92,7 +93,26 @@ Style: TopRight,Arial,30,&H00FFFFFF,&H000000FF,&H00282828,&H00000000,0,0,0,0,100
 [Events]
 Format: Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text"""
 
-    output_str = head_str + "\n" + subLines
+    output_str = utf8bom + head_str + "\n" + subLines
     #    output_str = output_str.encode(encoding)
 
     return output_str
+
+
+def srt2ass(input_file, output_file):
+    if '.ass' in input_file:
+        return input_file
+
+    src = fileopen(input_file)
+    tmp = src[0]
+    # encoding = src[1]
+    
+    output_str = srt2ass_from_string(tmp)   
+    #    output_str = output_str.encode(encoding)
+
+    with open(output_file, "w", encoding="utf8") as output:
+        output.write(output_str)
+
+    output_file = output_file.replace("\\", "\\\\")
+    output_file = output_file.replace("/", "//")
+    return output_file

--- a/docs/modules/ass.md
+++ b/docs/modules/ass.md
@@ -10,9 +10,123 @@ bilibili_api.ass
 from bilibili_api import ass
 ```
 
+- [class AssSubtitleObject()](#class-AssSubtitleObject)
+  - [def \_\_init\_\_()](#def-\_\_init\_\_)
+  - [def get\_lan\_list()](#def-get\_lan\_list)
+  - [async def request\_ass\_data\_json()](#async-def-request\_ass\_data\_json)
+  - [def to\_ass()](#def-to\_ass)
+  - [def to\_lrc()](#def-to\_lrc)
+  - [def to\_simple\_json()](#def-to\_simple\_json)
+  - [def to\_simple\_json\_str()](#def-to\_simple\_json\_str)
+  - [def to\_srt()](#def-to\_srt)
 - [async def make\_ass\_file\_danmakus\_protobuf()](#async-def-make\_ass\_file\_danmakus\_protobuf)
 - [async def make\_ass\_file\_danmakus\_xml()](#async-def-make\_ass\_file\_danmakus\_xml)
 - [async def make\_ass\_file\_subtitle()](#async-def-make\_ass\_file\_subtitle)
+- [async def make\_lrc\_file\_subtitle()](#async-def-make\_lrc\_file\_subtitle)
+- [async def make\_simple\_json\_file\_subtitle()](#async-def-make\_simple\_json\_file\_subtitle)
+- [async def make\_srt\_file\_subtitle()](#async-def-make\_srt\_file\_subtitle)
+- [async def request\_subtitle\_languages()](#async-def-request\_subtitle\_languages)
+- [async def request\_subtitle()](#async-def-request\_subtitle)
+
+---
+
+## class AssSubtitleObject()
+
+
+
+
+
+### def \_\_init\_\_()
+
+获取远程字幕
+
+
+| name | type | description |
+| - | - | - |
+| `json_lan_list` | `json` | 字幕可选语言 |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `lan_set` | `str` | 设置默认字幕语言,如果为None,则自动获取可获取语言 |
+
+
+### def get_lan_list()
+
+获取字幕语言列表
+
+
+
+**Returns:** `Tuple[List[str], List[Optional[str]]]`:  字幕名,字幕语言代码
+
+
+
+
+### async def request_ass_data_json()
+
+获取对应语言的字幕
+
+
+| name | type | description |
+| - | - | - |
+| `lan_set` | `str` | 如果为None，则获取默认字幕语言 |
+
+**Returns:** `json`:  字幕数据
+
+
+
+
+### def to_ass()
+
+获取ass格式的字幕
+
+
+
+**Returns:** `str`:  ass字幕
+
+
+
+
+### def to_lrc()
+
+获取lrc格式的字幕
+
+
+
+**Returns:** `str`:  lrc字幕
+
+
+
+
+### def to_simple_json()
+
+获取简化后的JSON数据
+
+
+
+**Returns:** `json`:  字幕数据
+
+
+
+
+### def to_simple_json_str()
+
+获取简化后的JSON字符串
+
+
+
+**Returns:** `str`:  获取简化后的JSON字符串
+
+
+
+
+### def to_srt()
+
+获取srt格式的字幕
+
+
+
+**Returns:** `str`:  srt字幕
+
+
+
 
 ---
 
@@ -71,7 +185,7 @@ from bilibili_api import ass
 
 ## async def make_ass_file_subtitle()
 
-生成视频字幕文件
+生成ass格式视频字幕文件
 
 编码默认采用 utf-8
 
@@ -85,6 +199,111 @@ from bilibili_api import ass
 | `lan_name` | `str, optional` | 字幕名，如”中文（自动生成）“,是简介的 subtitle 项的'list'项中的弹幕的'lan_doc'属性。Defaults to "中文（自动生成）". |
 | `lan_code` | `str, optional` | 字幕语言代码，如 ”中文（自动翻译）” 和 ”中文（自动生成）“ 为 "ai-zh" |
 | `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+
+
+
+---
+
+## async def make_lrc_file_subtitle()
+
+生成lrc格式视频字幕文件
+
+编码默认采用 utf-8
+
+
+| name | type | description |
+| - | - | - |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `page_index` | `int, optional` | 分 P 索引 |
+| `cid` | `int, optional` | cid |
+| `out` | `str, optional` | 输出位置. Defaults to "test.lrc". |
+| `lan_name` | `str, optional` | 字幕名，如”中文（自动生成）“,是简介的 subtitle 项的'list'项中的弹幕的'lan_doc'属性。Defaults to "中文（自动生成）". |
+| `lan_code` | `str, optional` | 字幕语言代码，如 ”中文（自动翻译）” 和 ”中文（自动生成）“ 为 "ai-zh" |
+| `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+
+
+
+---
+
+## async def make_simple_json_file_subtitle()
+
+生成简化后的json格式视频字幕文件
+
+编码默认采用 utf-8
+
+
+| name | type | description |
+| - | - | - |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `page_index` | `int, optional` | 分 P 索引 |
+| `cid` | `int, optional` | cid |
+| `out` | `str, optional` | 输出位置. Defaults to "test.json". |
+| `lan_name` | `str, optional` | 字幕名，如”中文（自动生成）“,是简介的 subtitle 项的'list'项中的弹幕的'lan_doc'属性。Defaults to "中文（自动生成）". |
+| `lan_code` | `str, optional` | 字幕语言代码，如 ”中文（自动翻译）” 和 ”中文（自动生成）“ 为 "ai-zh" |
+| `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+
+
+
+---
+
+## async def make_srt_file_subtitle()
+
+生成srt格式视频字幕文件
+
+编码默认采用 utf-8
+
+
+| name | type | description |
+| - | - | - |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `page_index` | `int, optional` | 分 P 索引 |
+| `cid` | `int, optional` | cid |
+| `out` | `str, optional` | 输出位置. Defaults to "test.srt". |
+| `lan_name` | `str, optional` | 字幕名，如”中文（自动生成）“,是简介的 subtitle 项的'list'项中的弹幕的'lan_doc'属性。Defaults to "中文（自动生成）". |
+| `lan_code` | `str, optional` | 字幕语言代码，如 ”中文（自动翻译）” 和 ”中文（自动生成）“ 为 "ai-zh" |
+| `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+
+
+
+---
+
+## async def request_subtitle_languages()
+
+获取远程字幕语言列表
+
+
+| name | type | description |
+| - | - | - |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `page_index` | `int, optional` | 分 P 索引 |
+| `cid` | `int, optional` | cid |
+| `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+**Returns:** `AssSubtitleObject`:  字幕对象
+
+
+
+---
+
+## async def request_subtitle()
+
+获取远程字幕
+
+
+| name | type | description |
+| - | - | - |
+| `obj` | `Union[Video,Episode]` | 对象 |
+| `page_index` | `int, optional` | 分 P 索引 |
+| `cid` | `int, optional` | cid |
+| `lan_name` | `str, optional` | 字幕名，如”中文（自动生成）“,是简介的 subtitle 项的'list'项中的弹幕的'lan_doc'属性。Defaults to "中文（自动生成）" 默认None 则自动获取可用歌词. |
+| `lan_code` | `str, optional` | 字幕语言代码，如 ”中文（自动翻译）” 和 ”中文（自动生成）“ 为 "ai-zh" 默认None 则自动获取可用歌词 |
+| `credential` | `Credential, optional` | Credential 类. 必须在此处或传入的视频 obj 中传入凭据，两者均存在则优先此处 |
+
+**Returns:** `AssSubtitleObject`:  字幕对象
 
 
 

--- a/tests/test_ass.py
+++ b/tests/test_ass.py
@@ -6,16 +6,19 @@ from .common import get_credential
 
 v = video.Video("BV1or4y1u7fk")
 
+
 async def test_a_ass_danmakus_protobuf():
     return await ass.make_ass_file_danmakus_protobuf(
         v, page=0, out="danmakus_protobuf.ass"
     )
 
+
 async def test_b_ass_danmakus_xml():
     return await ass.make_ass_file_danmakus_xml(v, page=0, out="danmakus_xml.ass")
 
+
 async def test_base_ass_json_data():
-    a = await ass.request_subtitle_lan_list(v, credential=get_credential())
+    a = await ass.request_subtitle_languages(v, credential=get_credential())
     print(await a.request_ass_data_str())
     print(a.to_srt())
     print(a.to_ass())
@@ -24,14 +27,18 @@ async def test_base_ass_json_data():
     print(a.to_simple_json_str())
     return
 
+
 async def test_c_ass_subtitle():
     return await ass.make_ass_file_subtitle(v, lan_name="中文（中国）", out="subtitle.ass", credential=get_credential())
+
 
 async def test_c_srt_subtitle():
     return await ass.make_srt_file_subtitle(v, lan_name="中文（中国）", out="subtitle.srt", credential=get_credential())
 
+
 async def test_c_lrc_subtitle():
     return await ass.make_lrc_file_subtitle(v, lan_name="中文（中国）", out="subtitle.lrc", credential=get_credential())
 
+
 async def test_c_json_subtitle():
-    return await ass.make_simpleJson_file_subtitle(v, lan_name="中文（中国）", out="subtitle.json", credential=get_credential())
+    return await ass.make_simple_json_file_subtitle(v, lan_name="中文（中国）", out="subtitle.json", credential=get_credential())


### PR DESCRIPTION
距离上次提交错误 main的重新提交
[last pr](https://github.com/Nemo2011/bilibili-api/pull/916)
按照之前的建议进行了修改

<img width="1478" height="675" alt="图片" src="https://github.com/user-attachments/assets/d29e2046-d985-45d7-9b47-f2538d850bf4" />

修改了字幕的测试文件

这是测试结果
<img width="2378" height="1375" alt="图片" src="https://github.com/user-attachments/assets/c7960f8b-6f88-4c12-84ee-51b8ef0ec2b0" />
