### PR TITLE
fix: handle potential error in SAR parsing for sar == "N/A"

### DIFF
--- a/bilibili_api/video.py
+++ b/bilibili_api/video.py
@@ -2476,7 +2476,7 @@ class VideoDownloadURLDataDetecter:
                     codecs=video_data["codecs"],
                     frame_rate=float(video_data["frame_rate"]),
                     scale=(video_data["width"], video_data["height"]),
-                    sar=tuple([int(x) for x in video_data["sar"].split(":")]),
+                    sar=tuple([int(x) for x in video_data["sar"].split(":")] if ":" in video_data["sar"] else (1, 1)),
                     mime_type=video_data["mime_type"],
                     segment_base_initialization=video_data["segment_base"]["initialization"],
                     segment_base_index_range=video_data["segment_base"]["index_range"]


### PR DESCRIPTION
# pip 上的最新版本对SAR的parsing有问题
- 修复sar为“N/A”的问题

比如bivd='BV1GYwtzHEA6'我那拿到的一个如
```
{'id': 32, 'baseUrl': 'https://upos-sz-mirrorcosov.bilivideo.com/upgcxcode/61/86/36696688661/36696688661-1-100023.m4s?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&trid=4049f91781ee4d7c987803ce629c3f0u&mid=0&nbs=1&deadline=1773858098&oi=2263296814&gen=playurlv3&og=cos&uipk=5&platform=pc&os=cosovbv&upsig=02ef21815fc25c9d032600a5ec3dd855&uparams=e,trid,mid,nbs,deadline,oi,gen,og,uipk,platform,os&bvc=vod&nettype=0&bw=243068&agrr=0&buvid=D21CC265-EFEE-02F0-90C7-FC18C13626C896641infoc&build=0&dl=0&f=u_0_0&qn_dyeid=33ffbccaa11b988500e21a3f69bad112&orderid=0,2', 'base_url': 'https://upos-sz-mirrorcosov.bilivideo.com/upgcxcode/61/86/36696688661/36696688661-1-100023.m4s?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&trid=4049f91781ee4d7c987803ce629c3f0u&mid=0&nbs=1&deadline=1773858098&oi=2263296814&gen=playurlv3&og=cos&uipk=5&platform=pc&os=cosovbv&upsig=02ef21815fc25c9d032600a5ec3dd855&uparams=e,trid,mid,nbs,deadline,oi,gen,og,uipk,platform,os&bvc=vod&nettype=0&bw=243068&agrr=0&buvid=D21CC265-EFEE-02F0-90C7-FC18C13626C896641infoc&build=0&dl=0&f=u_0_0&qn_dyeid=33ffbccaa11b988500e21a3f69bad112&orderid=0,2', 'backupUrl': ['https://upos-hz-mirrorakam.akamaized.net/upgcxcode/61/86/36696688661/36696688661-1-100023.m4s?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&og=cos&deadline=1773858098&oi=2263296814&gen=playurlv3&nbs=1&platform=pc&uipk=5&trid=4049f91781ee4d7c987803ce629c3f0u&mid=0&os=akam&upsig=dcf9d3c6c809a117a97d1c54fc0132e8&uparams=e,og,deadline,oi,gen,nbs,platform,uipk,trid,mid,os&hdnts=exp=1773858098~hmac=6bf0d29cea6a71632dd4d9a962e104bb1af6aa307e2228f4093bf671fb0de41f&bvc=vod&nettype=0&bw=243068&f=u_0_0&qn_dyeid=33ffbccaa11b988500e21a3f69bad112&agrr=0&buvid=D21CC265-EFEE-02F0-90C7-FC18C13626C896641infoc&build=0&dl=0&orderid=1,2'], 'backup_url': ['https://upos-hz-mirrorakam.akamaized.net/upgcxcode/61/86/36696688661/36696688661-1-100023.m4s?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&og=cos&deadline=1773858098&oi=2263296814&gen=playurlv3&nbs=1&platform=pc&uipk=5&trid=4049f91781ee4d7c987803ce629c3f0u&mid=0&os=akam&upsig=dcf9d3c6c809a117a97d1c54fc0132e8&uparams=e,og,deadline,oi,gen,nbs,platform,uipk,trid,mid,os&hdnts=exp=1773858098~hmac=6bf0d29cea6a71632dd4d9a962e104bb1af6aa307e2228f4093bf671fb0de41f&bvc=vod&nettype=0&bw=243068&f=u_0_0&qn_dyeid=33ffbccaa11b988500e21a3f69bad112&agrr=0&buvid=D21CC265-EFEE-02F0-90C7-FC18C13626C896641infoc&build=0&dl=0&orderid=1,2'], 'bandwidth': 243045, 'mimeType': 'video/mp4', 'mime_type': 'video/mp4', 'codecs': 'av01.0.00M.10.0.110.01.01.01.0', 'width': 852, 'height': 480, 'frameRate': '30.000', 'frame_rate': '30.000', 'sar': 'N/A', 'startWithSap': 1, 'start_with_sap': 1, 'SegmentBase': {'Initialization': '0-993', 'indexRange': '994-13229'}, 'segment_base': {'initialization': '0-993', 'index_range': '994-13229'}, 'codecid': 13}
```


```
'bandwidth': 243045, 'mimeType': 'video/mp4', 'mime_type': 'video/mp4', 'codecs': 'av01.0.00M.10.0.110.01.01.01.0', 'width': 852, 'height': 480, 'frameRate': '30.000', 'frame_rate': '30.000', 'sar': 'N/A', 'startWithSap': 1, 'start_with_sap': 1, 'SegmentBase': {'Initialization': '0-993', 'indexRange': '994-13229'}, 'segment_base': {'initialization': '0-993', 'index_range': '994-13229'}, 'codecid': 13}
```
