### PR TITLE
fix: 确保`__status`被设置成`STATUS_ERROR`

### DIFF
--- a/bilibili_api/live.py
+++ b/bilibili_api/live.py
@@ -1549,16 +1549,18 @@ class LiveDanmaku(AsyncEvent):
                     break
 
             except Exception as e:
+                self.logger.warning(e)
+                self.__status = self.STATUS_ERROR
+
                 if self.__ws:
                     await self.__client.ws_close(self.__ws)
-                self.logger.warning(e)
+
                 if retry <= 0 or len(available_hosts) == 0:
                     self.logger.error("无法连接服务器")
                     self.err_reason = "无法连接服务器"
                     break
 
                 self.logger.warning(f"将在 {self.retry_after} 秒后重新连接...")
-                self.__status = self.STATUS_ERROR
                 retry -= 1
                 await asyncio.sleep(self.retry_after)
 


### PR DESCRIPTION
在网络波动时
https://github.com/Nemo2011/bilibili-api/blob/0147ab61aa5a9f821c9b441cb1ddfdc761a3d999/bilibili_api/live.py#L1506-L1511
上述ws连接请求可能会抛出异常
https://github.com/Nemo2011/bilibili-api/blob/0147ab61aa5a9f821c9b441cb1ddfdc761a3d999/bilibili_api/live.py#L1551-L1558
在超过重试次数后若无法恢复，L1558的break会导致`LiveDanmaku`以`STATUS_CONNECTING`状态退出

本PR将`logger.warning`和设置`self.__status`部分提前，确保`__status`能在退出前被设置成`STATUS_ERROR`